### PR TITLE
IS451. LexemeLogger: log levels, sink pattern, LogTags per module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,10 @@ android {
         getByName("debug") {
             signingConfig = signingConfigs.getByName("signForRelease")
             isMinifyEnabled = false
+            val logLevel = project.findProperty("LOG_LEVEL")?.toString() ?: "DEBUG"
+            val remoteLogLevel = project.findProperty("REMOTE_LOG_LEVEL")?.toString() ?: "NONE"
+            buildConfigField("String", "LOG_LEVEL", "\"$logLevel\"")
+            buildConfigField("String", "REMOTE_LOG_LEVEL", "\"$remoteLogLevel\"")
         }
         getByName("release") {
             signingConfig = signingConfigs.getByName("signForRelease")
@@ -91,6 +95,10 @@ android {
                     getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-rules.pro"
             )
+            val logLevel = project.findProperty("LOG_LEVEL")?.toString() ?: "NONE"
+            val remoteLogLevel = project.findProperty("REMOTE_LOG_LEVEL")?.toString() ?: "WARNING"
+            buildConfigField("String", "LOG_LEVEL", "\"$logLevel\"")
+            buildConfigField("String", "REMOTE_LOG_LEVEL", "\"$remoteLogLevel\"")
         }
     }
 }

--- a/app/src/main/java/me/apomazkin/polytrainer/LogTags.kt
+++ b/app/src/main/java/me/apomazkin/polytrainer/LogTags.kt
@@ -1,0 +1,5 @@
+package me.apomazkin.polytrainer
+
+object LogTags {
+    const val APP = "###APP###"
+}

--- a/app/src/main/java/me/apomazkin/polytrainer/di/module/LoggerModule.kt
+++ b/app/src/main/java/me/apomazkin/polytrainer/di/module/LoggerModule.kt
@@ -1,12 +1,32 @@
 package me.apomazkin.polytrainer.di.module
 
-import dagger.Binds
 import dagger.Module
+import dagger.Provides
+import me.apomazkin.polytrainer.BuildConfig
+import me.apomazkin.polytrainer.logger.CrashlyticsSink
 import me.apomazkin.polytrainer.logger.LexemeLoggerImpl
+import me.apomazkin.polytrainer.logger.LogcatSink
 import me.apomazkin.ui.logger.LexemeLogger
+import me.apomazkin.ui.logger.LogLevel
+import me.apomazkin.ui.logger.LogSink
 
 @Module
-interface LoggerModule {
-    @Binds
-    fun bindLoggerImpl(impl: LexemeLoggerImpl): LexemeLogger
+object LoggerModule {
+
+    @Provides
+    fun provideSinks(): List<@JvmSuppressWildcards LogSink> = buildList {
+        val logLevel = BuildConfig.LOG_LEVEL
+        if (logLevel != "NONE") {
+            add(LogcatSink(LogLevel.valueOf(logLevel)))
+        }
+        val remoteLogLevel = BuildConfig.REMOTE_LOG_LEVEL
+        if (remoteLogLevel != "NONE") {
+            add(CrashlyticsSink(LogLevel.valueOf(remoteLogLevel)))
+        }
+    }
+
+    @Provides
+    fun provideLogger(sinks: List<@JvmSuppressWildcards LogSink>): LexemeLogger {
+        return LexemeLoggerImpl(sinks)
+    }
 }

--- a/app/src/main/java/me/apomazkin/polytrainer/logger/CrashlyticsSink.kt
+++ b/app/src/main/java/me/apomazkin/polytrainer/logger/CrashlyticsSink.kt
@@ -1,0 +1,21 @@
+package me.apomazkin.polytrainer.logger
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import me.apomazkin.ui.logger.LogLevel
+import me.apomazkin.ui.logger.LogSink
+
+class CrashlyticsSink(override val minLevel: LogLevel) : LogSink {
+    override fun write(level: LogLevel, tag: String, message: String) {
+        when (level) {
+            LogLevel.WARNING -> {
+                FirebaseCrashlytics.getInstance().log("$tag: $message")
+            }
+            LogLevel.ERROR -> {
+                FirebaseCrashlytics.getInstance().recordException(RuntimeException("$tag: $message"))
+            }
+            else -> {
+                // CrashlyticsSink only handles WARNING and ERROR
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/apomazkin/polytrainer/logger/LexemeLogger.kt
+++ b/app/src/main/java/me/apomazkin/polytrainer/logger/LexemeLogger.kt
@@ -1,11 +1,18 @@
 package me.apomazkin.polytrainer.logger
 
-import android.util.Log
 import me.apomazkin.ui.logger.LexemeLogger
+import me.apomazkin.ui.logger.LogLevel
+import me.apomazkin.ui.logger.LogSink
 import javax.inject.Inject
 
-class LexemeLoggerImpl @Inject constructor() : LexemeLogger {
-    override fun log(tag: String, message: String) {
-        Log.d(tag, message)
+class LexemeLoggerImpl @Inject constructor(
+    private val sinks: List<@JvmSuppressWildcards LogSink>
+) : LexemeLogger {
+    override fun log(level: LogLevel, tag: String, message: String) {
+        sinks.forEach { sink ->
+            if (level >= sink.minLevel) {
+                sink.write(level, tag, message)
+            }
+        }
     }
 }

--- a/app/src/main/java/me/apomazkin/polytrainer/logger/LogcatSink.kt
+++ b/app/src/main/java/me/apomazkin/polytrainer/logger/LogcatSink.kt
@@ -1,0 +1,16 @@
+package me.apomazkin.polytrainer.logger
+
+import android.util.Log
+import me.apomazkin.ui.logger.LogLevel
+import me.apomazkin.ui.logger.LogSink
+
+class LogcatSink(override val minLevel: LogLevel) : LogSink {
+    override fun write(level: LogLevel, tag: String, message: String) {
+        when (level) {
+            LogLevel.DEBUG -> Log.d(tag, message)
+            LogLevel.INFO -> Log.i(tag, message)
+            LogLevel.WARNING -> Log.w(tag, message)
+            LogLevel.ERROR -> Log.e(tag, message)
+        }
+    }
+}

--- a/app/src/main/java/me/apomazkin/polytrainer/uiDeps/MainUiDepsProvider.kt
+++ b/app/src/main/java/me/apomazkin/polytrainer/uiDeps/MainUiDepsProvider.kt
@@ -24,6 +24,7 @@ import me.apomazkin.settingstab.deps.SettingsTabUseCase
 import me.apomazkin.stattab.StatisticTabScreen
 import me.apomazkin.stattab.deps.StatisticUiDeps
 import me.apomazkin.stattab.deps.StatisticUseCase
+import me.apomazkin.polytrainer.LogTags
 import me.apomazkin.ui.logger.LexemeLogger
 import me.apomazkin.ui.resource.ResourceManager
 import me.apomazkin.wordcard.WordCardScreen
@@ -139,7 +140,7 @@ class MainUiDepsProvider(
             onLangManagementClick = onLangManagementClick,
             onAboutAppClick = onAboutAppClick,
             onPrivacyPolicyClick = {
-                logger.log(tag = "###Settings###", message = "navigate: privacy_policy")
+                logger.log(tag = me.apomazkin.settingstab.LogTags.SETTINGS, message = "navigate: privacy_policy")
                 onPrivacyPolicyClick()
             },
             settingsTabUseCase = settingsTabUseCase,
@@ -163,7 +164,7 @@ class MainUiDepsProvider(
         onBackPress: () -> Unit,
     ) {
         val webPage = WebPage.fromKey(pageKey) ?: run {
-            logger.log(tag = "###WebView###", message = "unknown pageKey: $pageKey")
+            logger.log(tag = LogTags.APP, message = "unknown pageKey: $pageKey")
             return
         }
         WebViewScreen(

--- a/core/core-db-impl/build.gradle.kts
+++ b/core/core-db-impl/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(diLibs.dagger)
     ksp(diLibs.daggerCompiler)
 
+    androidTestImplementation(project("path" to ":modules:core:ui"))
     androidTestImplementation(datastoreLibs.roomTesting)
     
     testImplementation("junit:junit:4.13.2")

--- a/core/core-db-impl/src/androidTest/java/me/apomazkin/core_db_impl/room/migrations/MigrationFrom07to08.kt
+++ b/core/core-db-impl/src/androidTest/java/me/apomazkin/core_db_impl/room/migrations/MigrationFrom07to08.kt
@@ -1,6 +1,5 @@
 package me.apomazkin.core_db_impl.room.migrations
 
-import android.util.Log
 import me.apomazkin.core_db_impl.entity.LexemeDb
 import me.apomazkin.core_db_impl.room.Schema
 import me.apomazkin.core_db_impl.room.base.BaseMigration
@@ -169,10 +168,6 @@ class MigrationFrom07to08 : BaseMigration() {
                     )
             },
             afterMigrationCheck = { database ->
-                Log.d(
-                    "###",
-                    "<MigrationFrom07to08.kt>::from07to08 => afterMigrationCheck"
-                )
                 database.hasTable(tableName = WordV8.tableName)
                 database.hasColumns(
                     tableName = WordV8.tableName,

--- a/core/core-db-impl/src/androidTest/java/me/apomazkin/core_db_impl/room/utils/CommonExtensions.kt
+++ b/core/core-db-impl/src/androidTest/java/me/apomazkin/core_db_impl/room/utils/CommonExtensions.kt
@@ -2,8 +2,8 @@ package me.apomazkin.core_db_impl.room.utils
 
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
-import android.util.Log
 import androidx.sqlite.db.SupportSQLiteDatabase
+import me.apomazkin.ui.logger.LexemeLogger
 import org.junit.Assert
 
 fun SupportSQLiteDatabase.hasTable(tableName: String) {
@@ -61,16 +61,17 @@ inline fun <reified MIGRATED, reified ORIGIN> List<MIGRATED>.checkData(
     originMatcher: List<ORIGIN>.(MIGRATED) -> ORIGIN?,
     checkMatcher: (migrated: MIGRATED, origin: ORIGIN) -> Boolean,
     afterMigrationState: Boolean = true,
+    logger: LexemeLogger? = null,
 ): List<MIGRATED> {
-    
+
     val logTitle =
         if (afterMigrationState) "Migration Test" else "Creating Test"
-    
+
     Assert.assertTrue(
         "Given count must be ${origin.size}, but here is ${this.size} (${MIGRATED::class.simpleName})",
         origin.size == this.size
     )
-    
+
     this.forEach { migratedItem ->
         val originItem = origin.originMatcher(migratedItem)
         Assert.assertNotNull(
@@ -78,14 +79,14 @@ inline fun <reified MIGRATED, reified ORIGIN> List<MIGRATED>.checkData(
             originItem
         )
         originItem?.let {
-            Log.d("###", "$logTitle: => \nm:$migratedItem\no:$it")
+            logger?.d(message = "$logTitle: => \nm:$migratedItem\no:$it")
             Assert.assertTrue(
                 "Database item $migratedItem doesn't match to origin item $it",
                 checkMatcher.invoke(migratedItem, it)
             )
         }
     }
-    
+
     return this
 }
 
@@ -94,15 +95,16 @@ inline fun <reified T> List<T>.checkItems(
     originMatcher: List<T>.(T) -> T?,
     checkMatcher: (migrated: T, origin: T) -> Boolean,
     afterMigrationState: Boolean = true,
+    logger: LexemeLogger? = null,
 ): List<T> {
-    
+
     val logTitle = if (afterMigrationState) "Migration Test" else "Creating Test"
-    
+
     Assert.assertTrue(
         "Given count must be ${origin.size}, but here is ${this.size} (${T::class.simpleName})",
         origin.size == this.size
     )
-    
+
     this.forEach { migratedItem ->
         val originItem = origin.originMatcher(migratedItem)
         Assert.assertNotNull(
@@ -110,13 +112,13 @@ inline fun <reified T> List<T>.checkItems(
             originItem
         )
         originItem?.let {
-            Log.d("###", "$logTitle: => \nm:$migratedItem\no:$it")
+            logger?.d(message = "$logTitle: => \nm:$migratedItem\no:$it")
             Assert.assertTrue(
                 "Database item doesn't match to origin item",
                 checkMatcher.invoke(migratedItem, it)
             )
         }
     }
-    
+
     return this
 }

--- a/core/core-db-impl/src/main/java/me/apomazkin/core_db_impl/CoreDbApiImpl.kt
+++ b/core/core-db-impl/src/main/java/me/apomazkin/core_db_impl/CoreDbApiImpl.kt
@@ -1,6 +1,5 @@
 package me.apomazkin.core_db_impl
 
-import android.util.Log
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
@@ -141,9 +140,6 @@ class CoreDbApiImpl @Inject constructor(
                     enablePlaceholders = false
                 ),
                 pagingSourceFactory = {
-                    if (BuildConfig.DEBUG) {
-                        Log.d("###", ">>>> TermsPaging => NEW PAGING SOURCE: $pattern")
-                    }
                     wordDao.searchTermsPaging(pattern, dictionaryId)
                 }
             ).flow.map { pagingData ->

--- a/core/core-db-impl/src/main/java/me/apomazkin/core_db_impl/LogTags.kt
+++ b/core/core-db-impl/src/main/java/me/apomazkin/core_db_impl/LogTags.kt
@@ -1,0 +1,5 @@
+package me.apomazkin.core_db_impl
+
+object LogTags {
+    const val DB = "###DB###"
+}

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -55,6 +55,19 @@
 
 ---
 
+- **[Правильный запуск Gradle из CLI (для агентов/CI)].**
+  Формат: `./gradlew <task> --console=plain >| /tmp/ff_<name>.log 2>&1; echo EXIT:$?`
+  - `--console=plain` — убирает escape-коды прогресс-бара
+  - `>| /tmp/...` — redirect в файл (не pipe), перезаписывает
+  - `echo EXIT:$?` — единственный видимый output = exit code
+  - Таймаут: 600000ms (10 мин)
+  - НЕ использовать `run_in_background` — ломает redirect
+  - НЕ использовать pipe (`| tail`) — Gradle может не flush'ить
+
+- **[Lint rule: запрет прямого android.util.Log].**
+  Написать кастомный lint check или CI grep-проверку. `android.util.Log` допустим только в `LogcatSink`. Везде остальное — через `LexemeLogger`.
+  Нужно: lint модуль с Detector + Issue, или detekt rule, или минимум grep в CI.
+
 - **[Централизованная система ошибок и снекбаров].**
   Сейчас каждый экран по-своему обрабатывает ошибки: кто-то Toast, кто-то Snackbar с boolean флагом, кто-то просто молчит. Нет единого механизма показа ошибок пользователю.
   Нужно: централизованный ErrorHandler / SnackbarManager. Единый API для показа ошибок из любого места (EffectHandler, WebView, навигация). Единый UI компонент (Snackbar/BottomSheet). Типизированные ошибки (network, unknown, validation).

--- a/docs/features-spec/logger.md
+++ b/docs/features-spec/logger.md
@@ -1,0 +1,73 @@
+# Logger
+
+## Обзор
+
+`LexemeLogger` — единый интерфейс логирования приложения. Поддерживает уровни severity и sink-паттерн для гибкого направления логов в различные destination.
+
+## Уровни логирования
+
+```kotlin
+enum class LogLevel { DEBUG, INFO, WARNING, ERROR }
+```
+
+Иерархия: DEBUG < INFO < WARNING < ERROR. Сообщение попадает в sink, если его уровень >= minLevel sink'а.
+
+## Интерфейс
+
+```kotlin
+// modules/core/ui
+interface LexemeLogger {
+    fun log(level: LogLevel = LogLevel.DEBUG, tag: String = "##LEXEME##", message: String)
+}
+```
+
+## Sink-паттерн
+
+```kotlin
+// modules/core/ui
+interface LogSink {
+    val minLevel: LogLevel
+    fun write(level: LogLevel, tag: String, message: String)
+}
+```
+
+`LexemeLoggerImpl` получает `List<LogSink>` через DI и итерирует при каждом вызове `log()`.
+
+### LogcatSink
+
+Пишет в Android Logcat:
+- DEBUG → `Log.d`
+- INFO → `Log.i`
+- WARNING → `Log.w`
+- ERROR → `Log.e`
+
+### CrashlyticsSink
+
+Пишет в Firebase Crashlytics:
+- WARNING → `Crashlytics.log(message)` (breadcrumbs, видны в контексте краша)
+- ERROR → `Crashlytics.recordException(RuntimeException("$tag: $message"))` (non-fatal)
+
+## Конфигурация уровней
+
+Build-type конфигурация через `BuildConfig`:
+
+| Build type | LOG_LEVEL (logcat) | REMOTE_LOG_LEVEL (Crashlytics) |
+|------------|-------------------|-------------------------------|
+| debug | DEBUG | NONE |
+| release | NONE | WARNING |
+
+`NONE` = sink не регистрируется.
+
+Переопределение: `./gradlew assembleRelease -PLOG_LEVEL=DEBUG -PREMOTE_LOG_LEVEL=ERROR`
+
+## Расширяемость
+
+Новый sink = новый класс `XxxSink : LogSink` + строчка в DI. Logger не меняется.
+
+## DI
+
+`LoggerModule` (Dagger):
+- Binds: `LexemeLoggerImpl` → `LexemeLogger`
+- Provides: `List<LogSink>` — собирает sink'и с учётом BuildConfig (NONE = не добавлять)
+
+_model: claude-opus-4-6_

--- a/docs/features/IS451_logger_levels/00_task.md
+++ b/docs/features/IS451_logger_levels/00_task.md
@@ -1,0 +1,57 @@
+# Task
+
+## IS451. Refactor: LexemeLogger — add log levels
+
+Рефакторинг логгера: добавить уровни логирования и sink-паттерн.
+
+## Текущее состояние
+
+- `LexemeLogger` — интерфейс в `core/ui`, один метод `log(tag, message)`
+- `LexemeLoggerImpl` — реализация в `app`, всё через `Log.d`
+- Прокидывается через Dagger (LoggerModule) и вручную через конструкторы
+- Тег по умолчанию `##MATE##` → менять на `##LEXEME##`
+
+## Требования
+
+- Добавить уровни: DEBUG, INFO, WARNING, ERROR
+- Иерархия: DEBUG < INFO < WARNING < ERROR — логируется всё от указанного уровня и выше
+- **Sink-паттерн:** Logger не знает куда пишет — итерирует список sink'ов
+  - `LogSink` — интерфейс с `minLevel` и `write(level, tag, message)`
+  - `LogcatSink` — пишет в logcat (Log.d/i/w/e)
+  - `CrashlyticsSink` — Firebase Crashlytics (уже подключен):
+    - WARNING → `Crashlytics.log(message)` (breadcrumbs, видны в контексте краша)
+    - ERROR → `Crashlytics.recordException(e)` (non-fatal, видны всегда в консоли)
+    - Если error без exception — формируем: `RuntimeException("$tag: $message")`
+  - Sink'и регистрируются в DI, Logger получает `List<LogSink>`
+  - Расширение = новый класс + строчка в DI, Logger не меняется
+  - Позже: AppMetricaSink (отдельная задача)
+- Фильтрация: каждый sink имеет свой minLevel, задаётся при сборке через BuildConfig
+  - Дефолты:
+    - debug: LOG_LEVEL=DEBUG, REMOTE_LOG_LEVEL=NONE (локально всё, удалённо ничего)
+    - release: LOG_LEVEL=NONE, REMOTE_LOG_LEVEL=WARNING (локально ничего, удалённо warning+error)
+  - Переопределение: `./gradlew assembleRelease -PLOG_LEVEL=DEBUG -PREMOTE_LOG_LEVEL=ERROR`
+- Обратная совместимость: существующие вызовы `log(tag, message)` продолжают работать (default level = DEBUG)
+- Миграция существующих вызовов не обязательна в рамках этой задачи
+
+## Архитектура
+
+```
+LexemeLogger.log(level, tag, message)
+    └── sinks.forEach { if (level >= sink.minLevel) sink.write(...) }
+            ├── LogcatSink(minLevel from BuildConfig.LOG_LEVEL)
+            ├── CrashlyticsSink(minLevel from BuildConfig.REMOTE_LOG_LEVEL)
+            │       ├── WARNING → Crashlytics.log(message)
+            │       └── ERROR → Crashlytics.recordException(e)
+            └── [будущее: AppMetricaSink, FileSink, ...]
+```
+
+## Затронутые файлы
+
+- `modules/core/ui/.../LexemeLogger.kt` — интерфейс (добавить level параметр)
+- `modules/core/ui/.../LogLevel.kt` — enum уровней (новый)
+- `modules/core/ui/.../LogSink.kt` — интерфейс sink'а (новый)
+- `app/.../logger/LexemeLoggerImpl.kt` — реализация (итерация по sink'ам)
+- `app/.../logger/LogcatSink.kt` — logcat sink (новый)
+- `app/.../logger/CrashlyticsSink.kt` — Firebase Crashlytics sink (новый)
+- `app/.../di/module/LoggerModule.kt` — DI конфигурация
+- `app/build.gradle.kts` — buildConfigField для LOG_LEVEL, REMOTE_LOG_LEVEL

--- a/docs/features/IS451_logger_levels/01_spec.md
+++ b/docs/features/IS451_logger_levels/01_spec.md
@@ -1,0 +1,175 @@
+# Spec: IS451 — LexemeLogger: уровни логирования и sink-паттерн
+
+## Проблема
+
+Текущий логгер (`LexemeLogger`) имеет единственный метод `log(tag, message)`, который всегда пишет в `Log.d`. Нет:
+- Уровней логирования (всё = debug)
+- Фильтрации по severity
+- Возможности направлять логи в разные destination (logcat, Crashlytics, AppMetrica)
+- Гибкой конфигурации per-build-type
+
+## Что остаётся без изменений
+
+- Пакет интерфейса: `me.apomazkin.ui.logger` в `modules/core/ui`
+- Пакет реализации: `me.apomazkin.polytrainer.logger` в `app`
+- DI-модуль: `LoggerModule` в `app/.../di/module/`
+- Точки вызова логгера по коду — мигрируются на шорткаты d/i/w/e
+
+## Что удаляется
+
+- Дефолтный тег `##MATE##` → заменяется на `##LEXEME##`
+- Прямой вызов `Log.d` в `LexemeLoggerImpl` → заменяется на итерацию по sink'ам
+
+## Что добавляется / меняется
+
+### 1. LogLevel — enum уровней
+
+Файл: `modules/core/ui/.../logger/LogLevel.kt`
+
+```kotlin
+enum class LogLevel { DEBUG, INFO, WARNING, ERROR }
+```
+
+Иерархия: DEBUG < INFO < WARNING < ERROR. Sink логирует сообщение, если `messageLevel >= sink.minLevel`.
+
+### 2. LogSink — интерфейс sink'а
+
+Файл: `modules/core/ui/.../logger/LogSink.kt`
+
+```kotlin
+interface LogSink {
+    val minLevel: LogLevel
+    fun write(level: LogLevel, tag: String, message: String)
+}
+```
+
+### 3. LexemeLogger — расширение интерфейса
+
+Файл: `modules/core/ui/.../logger/LexemeLogger.kt`
+
+**Было:**
+```kotlin
+interface LexemeLogger {
+    fun log(tag: String = "##MATE##", message: String)
+}
+```
+
+**Стало:**
+```kotlin
+interface LexemeLogger {
+    fun log(level: LogLevel = LogLevel.DEBUG, tag: String = "##LEXEME##", message: String)
+    
+    fun d(tag: String = "##LEXEME##", message: String) = log(LogLevel.DEBUG, tag, message)
+    fun i(tag: String = "##LEXEME##", message: String) = log(LogLevel.INFO, tag, message)
+    fun w(tag: String = "##LEXEME##", message: String) = log(LogLevel.WARNING, tag, message)
+    fun e(tag: String = "##LEXEME##", message: String) = log(LogLevel.ERROR, tag, message)
+}
+```
+
+⚠️ НЕ backward compatible: вызовы `log("TAG", "msg")` сломаются — первый позиционный параметр теперь `LogLevel`. Миграция всех call-site обязательна.
+
+### 4. LexemeLoggerImpl — итерация по sink'ам
+
+Файл: `app/.../logger/LexemeLoggerImpl.kt`
+
+**Было:** прямой `Log.d`
+**Стало:** получает `List<LogSink>` через конструктор, итерирует:
+
+```kotlin
+class LexemeLoggerImpl @Inject constructor(
+    private val sinks: List<@JvmSuppressWildcards LogSink>
+) : LexemeLogger {
+    override fun log(level: LogLevel, tag: String, message: String) {
+        sinks.forEach { sink ->
+            if (level >= sink.minLevel) {
+                sink.write(level, tag, message)
+            }
+        }
+    }
+}
+```
+
+### 5. LogcatSink
+
+Файл: `app/.../logger/LogcatSink.kt`
+
+Пишет в Android Logcat, маппинг уровней:
+- DEBUG → `Log.d`
+- INFO → `Log.i`
+- WARNING → `Log.w`
+- ERROR → `Log.e`
+
+`minLevel` из `BuildConfig.LOG_LEVEL`.
+
+### 6. CrashlyticsSink
+
+Файл: `app/.../logger/CrashlyticsSink.kt`
+
+Пишет в Firebase Crashlytics:
+- WARNING → `FirebaseCrashlytics.getInstance().log(message)` (breadcrumbs)
+- ERROR → `FirebaseCrashlytics.getInstance().recordException(RuntimeException("$tag: $message"))`
+
+`minLevel` из `BuildConfig.REMOTE_LOG_LEVEL`.
+
+### 7. BuildConfig — уровни фильтрации
+
+Файл: `app/build.gradle.kts`
+
+```kotlin
+buildTypes {
+    debug {
+        buildConfigField("String", "LOG_LEVEL", "\"DEBUG\"")
+        buildConfigField("String", "REMOTE_LOG_LEVEL", "\"NONE\"")
+    }
+    release {
+        buildConfigField("String", "LOG_LEVEL", "\"NONE\"")
+        buildConfigField("String", "REMOTE_LOG_LEVEL", "\"WARNING\"")
+    }
+}
+```
+
+Переопределение через gradle properties:
+```
+./gradlew assembleRelease -PLOG_LEVEL=DEBUG -PREMOTE_LOG_LEVEL=ERROR
+```
+
+NONE = sink не добавляется в DI (или minLevel выше любого уровня).
+
+### 8. LoggerModule — DI конфигурация
+
+Файл: `app/.../di/module/LoggerModule.kt`
+
+- Binds `LexemeLoggerImpl` → `LexemeLogger`
+- Provides `List<LogSink>` (LogcatSink + CrashlyticsSink, фильтруя NONE)
+- LogcatSink: `minLevel = LogLevel.valueOf(BuildConfig.LOG_LEVEL)` (если не NONE)
+- CrashlyticsSink: `minLevel = LogLevel.valueOf(BuildConfig.REMOTE_LOG_LEVEL)` (если не NONE)
+
+### 9. Тег по умолчанию
+
+`##MATE##` → `##LEXEME##` в дефолтном параметре интерфейса.
+
+## Файлы
+
+| Файл | Действие |
+|------|----------|
+| `modules/core/ui/src/main/java/me/apomazkin/ui/logger/LogLevel.kt` | Создать |
+| `modules/core/ui/src/main/java/me/apomazkin/ui/logger/LogSink.kt` | Создать |
+| `modules/core/ui/src/main/java/me/apomazkin/ui/logger/LexemeLogger.kt` | Изменить |
+| `app/src/main/java/me/apomazkin/polytrainer/logger/LexemeLoggerImpl.kt` | Изменить |
+| `app/src/main/java/me/apomazkin/polytrainer/logger/LogcatSink.kt` | Создать |
+| `app/src/main/java/me/apomazkin/polytrainer/logger/CrashlyticsSink.kt` | Создать |
+| `app/src/main/java/me/apomazkin/polytrainer/di/module/LoggerModule.kt` | Изменить |
+| `app/build.gradle.kts` | Изменить |
+
+## Дополнительно
+
+- Миграция существующих вызовов `log(tag, message)` к использованию шорткатов `d()`, `i()`, `w()`, `e()` — IN SCOPE
+- Запретить прямые вызовы `android.util.Log` в коде (lint rule или convention)
+- Убрать `import android.util.Log` из всех файлов кроме `LogcatSink`
+
+## Ограничения
+
+- AppMetricaSink — отдельная задача
+- FileSink — отдельная задача
+
+_model: claude-opus-4-6_

--- a/docs/features/IS451_logger_levels/06_design_tree.md
+++ b/docs/features/IS451_logger_levels/06_design_tree.md
@@ -1,0 +1,311 @@
+# Design Tree: IS451 — Logger Levels
+
+## Graph
+
+```yaml
+- id: 0
+  file: modules/core/ui/src/main/java/me/apomazkin/ui/logger/LogLevel.kt
+  action: "+"
+  depends: []
+
+- id: 1
+  file: modules/core/ui/src/main/java/me/apomazkin/ui/logger/LogSink.kt
+  action: "+"
+  depends: [0]
+
+- id: 2
+  file: modules/core/ui/src/main/java/me/apomazkin/ui/logger/LexemeLogger.kt
+  action: "~"
+  depends: [0]
+
+- id: 3
+  file: app/src/main/java/me/apomazkin/polytrainer/logger/LogcatSink.kt
+  action: "+"
+  depends: [0, 1]
+
+- id: 4
+  file: app/src/main/java/me/apomazkin/polytrainer/logger/CrashlyticsSink.kt
+  action: "+"
+  depends: [0, 1]
+
+- id: 5
+  file: app/src/main/java/me/apomazkin/polytrainer/logger/LexemeLoggerImpl.kt
+  action: "~"
+  depends: [0, 1, 2]
+
+- id: 6
+  file: app/build.gradle.kts
+  action: "~"
+  depends: []
+
+- id: 7
+  file: app/src/main/java/me/apomazkin/polytrainer/di/module/LoggerModule.kt
+  action: "~"
+  depends: [3, 4, 5, 6]
+
+- id: 8
+  file: modules/screen/stattab/src/main/java/me/apomazkin/stattab/mate/DatasourceEffectHandler.kt
+  action: "~"
+  depends: [2]
+
+- id: 9
+  file: modules/screen/dictionaryTab/src/main/java/me/apomazkin/dictionarytab/logic/DatasourceEffectHandler.kt
+  action: "~"
+  depends: [2]
+
+- id: 10
+  file: modules/screen/quiztab/src/main/java/me/apomazkin/quiztab/logic/DatasourceEffectHandler.kt
+  action: "~"
+  depends: [2]
+
+- id: 11
+  file: modules/screen/quiz/chat/src/main/java/me/apomazkin/quiz/chat/logic/DatasourceEffectHandler.kt
+  action: "~"
+  depends: [2]
+
+- id: 12
+  file: modules/screen/settingstab/src/main/java/me/apomazkin/settingstab/logic/DatasourceEffectHandler.kt
+  action: "~"
+  depends: [2]
+
+- id: 13
+  file: modules/widget/dictionaryappbar/src/main/java/me/apomazkin/dictionaryappbar/mate/DatasourceEffectHandler.kt
+  action: "~"
+  depends: [2]
+
+- id: 14
+  file: modules/screen/main/src/main/java/me/apomazkin/main/Settings.kt
+  action: "~"
+  depends: [2]
+
+- id: 15
+  file: modules/screen/quiz/chat/src/main/java/me/apomazkin/quiz/chat/quiz/QuizGameImpl.kt
+  action: "~"
+  depends: [2]
+
+- id: 16
+  file: core/core-db-impl/src/main/java/me/apomazkin/core_db_impl/CoreDbApiImpl.kt
+  action: "~"
+  depends: [2]
+
+- id: 17
+  file: core/core-db-impl/src/androidTest/java/me/apomazkin/core_db_impl/room/migrations/MigrationFrom07to08.kt
+  action: "~"
+  depends: []
+
+- id: 18
+  file: core/core-db-impl/src/androidTest/java/me/apomazkin/core_db_impl/room/utils/CommonExtensions.kt
+  action: "~"
+  depends: [2]
+```
+
+## Details
+
+### #0 LogLevel.kt [+]
+
+Enum levels for log severity. Implements `Comparable` naturally (enum ordinal).
+
+```kotlin
+enum class LogLevel { DEBUG, INFO, WARNING, ERROR }
+```
+
+### #1 LogSink.kt [+]
+
+Interface for log destinations. Depends on LogLevel.
+
+```kotlin
+interface LogSink {
+    val minLevel: LogLevel
+    fun write(level: LogLevel, tag: String, message: String)
+}
+```
+
+### #2 LexemeLogger.kt [~]
+
+Extend interface with level parameter and shortcut methods. 📎 guide: code-style (logging conventions).
+
+**Was:**
+```kotlin
+interface LexemeLogger {
+    fun log(tag: String = "##MATE##", message: String)
+}
+```
+
+**Becomes:**
+```kotlin
+interface LexemeLogger {
+    fun log(level: LogLevel = LogLevel.DEBUG, tag: String = "##LEXEME##", message: String)
+
+    fun d(tag: String = "##LEXEME##", message: String) = log(LogLevel.DEBUG, tag, message)
+    fun i(tag: String = "##LEXEME##", message: String) = log(LogLevel.INFO, tag, message)
+    fun w(tag: String = "##LEXEME##", message: String) = log(LogLevel.WARNING, tag, message)
+    fun e(tag: String = "##LEXEME##", message: String) = log(LogLevel.ERROR, tag, message)
+}
+```
+
+⚠️ НЕ backward compatible: существующие вызовы `log("TAG", "msg")` сломаются — первый позиционный параметр теперь `LogLevel`. Миграция (#8-#16) обязательна для компиляции.
+
+### #3 LogcatSink.kt [+]
+
+Sink writing to Android Logcat. Maps LogLevel to `Log.d/i/w/e`. Only file allowed to use `android.util.Log`. 📎 guide: code-style (logging ban).
+
+```kotlin
+class LogcatSink(override val minLevel: LogLevel) : LogSink {
+    override fun write(level: LogLevel, tag: String, message: String)
+    // DEBUG -> Log.d, INFO -> Log.i, WARNING -> Log.w, ERROR -> Log.e
+}
+```
+
+### #4 CrashlyticsSink.kt [+]
+
+Sink writing to Firebase Crashlytics. WARNING -> breadcrumb (`Crashlytics.log`), ERROR -> non-fatal (`Crashlytics.recordException`).
+
+```kotlin
+class CrashlyticsSink(override val minLevel: LogLevel) : LogSink {
+    override fun write(level: LogLevel, tag: String, message: String)
+    // WARNING -> FirebaseCrashlytics.getInstance().log("$tag: $message")
+    // ERROR -> FirebaseCrashlytics.getInstance().recordException(RuntimeException("$tag: $message"))
+}
+```
+
+### #5 LexemeLoggerImpl.kt [~]
+
+Replace direct `Log.d` with sink iteration.
+
+**Was:**
+```kotlin
+class LexemeLoggerImpl @Inject constructor() : LexemeLogger {
+    override fun log(tag: String, message: String) {
+        Log.d(tag, message)
+    }
+}
+```
+
+**Becomes:**
+```kotlin
+class LexemeLoggerImpl @Inject constructor(
+    private val sinks: List<@JvmSuppressWildcards LogSink>
+) : LexemeLogger {
+    override fun log(level: LogLevel, tag: String, message: String) {
+        sinks.forEach { sink ->
+            if (level >= sink.minLevel) sink.write(level, tag, message)
+        }
+    }
+}
+```
+
+Remove `import android.util.Log`.
+
+### #6 app/build.gradle.kts [~]
+
+Add `buildConfigField` for log levels in `buildTypes`.
+
+**Was:** no log-level fields in buildTypes.
+
+**Becomes:**
+```kotlin
+buildTypes {
+    getByName("debug") {
+        // ... existing config ...
+        buildConfigField("String", "LOG_LEVEL", "\"DEBUG\"")
+        buildConfigField("String", "REMOTE_LOG_LEVEL", "\"NONE\"")
+    }
+    getByName("release") {
+        // ... existing config ...
+        buildConfigField("String", "LOG_LEVEL", "\"NONE\"")
+        buildConfigField("String", "REMOTE_LOG_LEVEL", "\"WARNING\"")
+    }
+}
+```
+
+Support gradle property override: read from `project.findProperty("LOG_LEVEL")` with fallback to hardcoded default.
+
+### #7 LoggerModule.kt [~]
+
+Rewrite from `@Binds` interface to `@Module` object with `@Provides` methods.
+
+**Was:**
+```kotlin
+@Module
+interface LoggerModule {
+    @Binds
+    fun bindLoggerImpl(impl: LexemeLoggerImpl): LexemeLogger
+}
+```
+
+**Becomes:**
+```kotlin
+@Module
+object LoggerModule {
+    @Provides
+    fun provideSinks(): List<@JvmSuppressWildcards LogSink> = buildList {
+        if (BuildConfig.LOG_LEVEL != "NONE") {
+            add(LogcatSink(LogLevel.valueOf(BuildConfig.LOG_LEVEL)))
+        }
+        if (BuildConfig.REMOTE_LOG_LEVEL != "NONE") {
+            add(CrashlyticsSink(LogLevel.valueOf(BuildConfig.REMOTE_LOG_LEVEL)))
+        }
+    }
+
+    @Provides
+    fun provideLogger(sinks: List<@JvmSuppressWildcards LogSink>): LexemeLogger {
+        return LexemeLoggerImpl(sinks)
+    }
+}
+```
+
+### #8 stattab/DatasourceEffectHandler.kt [~]
+
+Remove `import android.util.Log` and replace direct `Log.*` calls with `LexemeLogger` calls using `d()` shortcut.
+
+### #9 dictionarytab/DatasourceEffectHandler.kt [~]
+
+Remove `import android.util.Log` and replace direct `Log.*` calls with `LexemeLogger` calls using `d()` shortcut.
+
+### #10 quiztab/DatasourceEffectHandler.kt [~]
+
+Remove `import android.util.Log` and replace direct `Log.*` calls with `LexemeLogger` calls using `d()` shortcut.
+
+### #11 quiz/chat/DatasourceEffectHandler.kt [~]
+
+Remove `import android.util.Log` and replace direct `Log.*` calls with `LexemeLogger` calls using `d()` shortcut.
+
+### #12 settingstab/DatasourceEffectHandler.kt [~]
+
+Remove `import android.util.Log` and replace direct `Log.*` calls with `LexemeLogger` calls using `d()` shortcut.
+
+### #13 dictionaryappbar/DatasourceEffectHandler.kt [~]
+
+Remove `import android.util.Log` and replace direct `Log.*` calls with `LexemeLogger` calls using `d()` shortcut.
+
+### #14 main/Settings.kt [~]
+
+Удалить `import android.util.Log` и вызов `Log.e(...)`. Лог дублируется в MainUiDepsProvider (`unknown pageKey`). Замена на LexemeLogger не нужна.
+
+### #15 quiz/chat/QuizGameImpl.kt [~]
+
+Remove `import android.util.Log` and replace direct `Log.*` calls with `LexemeLogger` calls using `d()` shortcut.
+
+### #16 core-db-impl/CoreDbApiImpl.kt [~]
+
+Remove `import android.util.Log` and replace direct `Log.*` calls with `LexemeLogger` calls using `d()` shortcut.
+
+## Parallelism
+
+- Layer 0 (no deps): #0, #6
+- Layer 1 (deps on #0): #1, #2
+- Layer 2 (deps on #0, #1, #2): #3, #4, #5
+- Layer 3 (deps on sinks + impl): #7
+- Migration (deps on #2 only, parallel to each other): #8, #9, #10, #11, #12, #13, #14, #15, #16
+
+## Notes
+
+- Nodes #8-#16 are migration nodes. Each removes direct `android.util.Log` usage and replaces with `LexemeLogger`. Some of these files may not have `LexemeLogger` injected yet — will need constructor injection or parameter passing.
+
+### #17 MigrationFrom07to08.kt [~]
+
+Удалить мусорный `Log.d("###", ...)` и `import android.util.Log`. Лог не несёт ценности.
+
+### #18 CommonExtensions.kt [~]
+
+Добавить опциональный параметр `logger: LexemeLogger? = null`. Заменить `Log.d(...)` на `logger?.d(...)`. Удалить `import android.util.Log`.

--- a/docs/features/IS451_logger_levels/checklist.md
+++ b/docs/features/IS451_logger_levels/checklist.md
@@ -1,0 +1,48 @@
+# Checklist
+
+- [ ] Вызов `logger.log(level, tag, message)` → сообщение доставляется во все sink'и с `minLevel <= level` [spec]
+  - [ ] Лог: ###LEXEME### dispatch message to N sinks [spec]
+- [ ] Вызов `logger.d/i/w/e(tag, message)` → маппится на соответствующий LogLevel и проходит через sink'и [spec]
+  - [ ] Лог: ###LEXEME### shortcut method delegates to log() [spec]
+- [ ] LogcatSink пишет в Logcat с правильным уровнем (d→Log.d, i→Log.i, w→Log.w, e→Log.e) [spec]
+  - [ ] Лог: ###LEXEME### LogcatSink.write level=X [spec]
+- [ ] CrashlyticsSink: WARNING → `Crashlytics.log()`, ERROR → `Crashlytics.recordException()` [spec]
+  - [ ] Лог: ###LEXEME### CrashlyticsSink.write level=X [spec]
+- [ ] Debug build: LogcatSink active (minLevel=DEBUG), CrashlyticsSink disabled (NONE) [spec]
+  - [ ] Лог: ###LEXEME### sink configuration: logcat=DEBUG, remote=NONE [spec]
+- [ ] Release build: LogcatSink disabled (NONE), CrashlyticsSink active (minLevel=WARNING) [spec]
+  - [ ] Лог: ###LEXEME### sink configuration: logcat=NONE, remote=WARNING [spec]
+- [ ] Миграция: все существующие `log(tag, message)` переведены на шорткаты d/i/w/e [spec]
+- [ ] Запрет: прямых вызовов `android.util.Log` нет нигде кроме LogcatSink [spec]
+
+## Ручное тестирование
+
+### Логирование в debug-сборке
+1. Собрать debug APK (`./gradlew assembleDebug`)
+2. Запустить приложение
+3. Выполнить любое действие, вызывающее логирование (напр. открыть словарь)
+4. Ожидание: в Logcat видны сообщения с тегом `##LEXEME##` уровня DEBUG
+5. Логи:
+   - `###LEXEME### LogcatSink.write level=DEBUG`
+
+### Уровни в Logcat
+1. Добавить временный вызов `logger.e("TEST", "error message")` в любой экран
+2. Запустить debug-сборку
+3. Фильтровать Logcat по тегу `TEST`
+4. Ожидание: сообщение отображается как ERROR (красный) в Logcat
+5. Логи:
+   - `###LEXEME### LogcatSink.write level=ERROR`
+
+### CrashlyticsSink в release
+1. Собрать release APK с `REMOTE_LOG_LEVEL=WARNING`
+2. Вызвать `logger.w("TEST", "warning breadcrumb")`
+3. Вызвать `logger.e("TEST", "error exception")`
+4. Ожидание: в Firebase Console — breadcrumb для warning, non-fatal exception для error
+5. Логи:
+   - `###LEXEME### CrashlyticsSink.write level=WARNING`
+   - `###LEXEME### CrashlyticsSink.write level=ERROR`
+
+### Миграция и запрет Log
+1. Проверить что нет `import android.util.Log` нигде кроме LogcatSink
+2. Проверить что все вызовы `logger.log(tag, message)` заменены на `logger.d/i/w/e`
+3. Собрать debug APK — компиляция ✅

--- a/docs/features/IS451_logger_levels/log.md
+++ b/docs/features/IS451_logger_levels/log.md
@@ -1,0 +1,5 @@
+<br>[00:10:00] flow: lexeme_feature → старт
+<br>[00:10:00] step: task → done
+<br>[00:15:00] step: spec → done
+<br>[00:23:28] step: checklist_init → done (7 корневых пунктов, 4 сценария ручного тестирования)
+<br>[00:30:57] step: design_tree → done (17 узлов: 4 [+], 13 [~], 0 [-]; 5 параллельных слоёв)

--- a/docs/features/IS451_logger_levels/plan.yml
+++ b/docs/features/IS451_logger_levels/plan.yml
@@ -1,0 +1,52 @@
+flow: lexeme_feature
+started: "2026-05-06T00:10:00"
+dir: docs/features/IS451_logger_levels/
+
+context:
+  ticket: IS451
+  feature_name: logger_levels
+  branch: IS451-logger-levels
+  mode: normal
+
+steps:
+  task:
+    status: done
+    finished: "2026-05-06T00:10:00"
+
+  spec:
+    status: done
+    finished: "2026-05-06T00:15:00"
+
+  checklist_init:
+    status: done
+    finished: "2026-05-06T00:23:28"
+
+  contract:
+    type: group
+    status: skipped
+
+  usecase:
+    status: skipped
+
+  design_tree:
+    status: done
+    finished: "2026-05-06T00:30:57"
+    pause: true
+
+  test:
+    status: skipped
+
+  implement:
+    status: pending
+    pause: true
+
+  check:
+    status: pending
+    pause: true
+
+  checklist_run:
+    status: pending
+
+  publish_spec:
+    status: pending
+    pause: true

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -36,5 +36,6 @@
 ## Стиль и конвенции
 
 - [Стиль кода](code-style.md) — форматирование, именование, git-конвенции, gradle
+- [Логирование](logging.md) — LexemeLogger, sink-паттерн, уровни, теги, конфигурация
 - [Тема и ресурсы](theme-and-resources.md) — цвета, типографика, ResourceManager, иконки, превью
 - [Утилиты](tools-utils.md) — хелперы для работы со списками (modifyFiltered, insertToEnd)

--- a/docs/guides/code-style.md
+++ b/docs/guides/code-style.md
@@ -42,18 +42,9 @@ me.apomazkin.<module>.entity   — Domain модели
 - Эффекты: `DatasourceEffect`, `UiEffect` (sealed interface extends `Effect`)
 - UseCases: интерфейс `*UseCase`, реализация `*UseCaseImpl`
 
-### Формат отладочных логов
+### Логирование
 
-Тег: `###СМЫСЛОВОЕ_СЛОВО###` — тройные решётки + слово описывающее область отладки.
-
-```kotlin
-android.util.Log.d("###FILTER###", "updateFilter: query='$query'")
-android.util.Log.d("###NAVIGATION###", "Back: onBack called")
-```
-
-- Тег всегда в формате `###СЛОВО###` — легко искать в Logcat, легко грепать для удаления
-- Логи временные — удалять после отладки. Не коммитить
-- Смысловое слово — область (FILTER, NAVIGATION, LOADING, STATE), не имя класса
+См. отдельный гайд: [logging.md](logging.md)
 
 ### Принцип именования
 

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -1,0 +1,144 @@
+# Логирование
+
+## ЗАПРЕТ
+
+**ЗАПРЕЩЕНО** использовать `android.util.Log` напрямую. Единственное место — `LogcatSink`.
+Всё логирование — через `LexemeLogger`. Без исключений.
+
+## Архитектура
+
+```
+LexemeLogger.log(level, tag, message)
+    └── sinks.forEach { if (level >= sink.minLevel) sink.write(...) }
+            ├── LogcatSink  → android.util.Log.d/i/w/e
+            └── CrashlyticsSink → Crashlytics.log / recordException
+```
+
+### Sink-паттерн
+
+`LexemeLogger` не знает куда пишет. Он итерирует `List<LogSink>`, каждый sink:
+- Имеет свой `minLevel` — фильтрует сообщения ниже порога
+- Реализует `write(level, tag, message)` — пишет в своё направление
+
+Добавить новый sink = создать класс + зарегистрировать в DI (`LoggerModule`). Logger не меняется.
+
+### Существующие sink'и
+
+| Sink | Куда | Маппинг уровней |
+|------|------|-----------------|
+| `LogcatSink` | Android Logcat | DEBUG→Log.d, INFO→Log.i, WARNING→Log.w, ERROR→Log.e |
+| `CrashlyticsSink` | Firebase Crashlytics | WARNING→breadcrumb (`Crashlytics.log`), ERROR→non-fatal (`recordException`) |
+
+### Конфигурация при сборке
+
+Каждый sink имеет свой `minLevel` из `BuildConfig`:
+
+| Build type | LOG_LEVEL (logcat) | REMOTE_LOG_LEVEL (crashlytics) |
+|------------|--------------------|---------------------------------|
+| debug | DEBUG | NONE (отключен) |
+| release | NONE (отключен) | WARNING |
+
+`NONE` — sink не создаётся.
+
+Переопределение через gradle property:
+```bash
+./gradlew assembleRelease -PLOG_LEVEL=DEBUG -PREMOTE_LOG_LEVEL=ERROR
+```
+
+### DI
+
+```kotlin
+// LoggerModule.kt
+@Module
+object LoggerModule {
+    @Provides
+    fun provideSinks(): List<LogSink> = buildList {
+        if (BuildConfig.LOG_LEVEL != "NONE") {
+            add(LogcatSink(LogLevel.valueOf(BuildConfig.LOG_LEVEL)))
+        }
+        if (BuildConfig.REMOTE_LOG_LEVEL != "NONE") {
+            add(CrashlyticsSink(LogLevel.valueOf(BuildConfig.REMOTE_LOG_LEVEL)))
+        }
+    }
+
+    @Provides
+    fun provideLogger(sinks: List<LogSink>): LexemeLogger = LexemeLoggerImpl(sinks)
+}
+```
+
+## Уровни
+
+| Уровень | Метод | Когда использовать | Куда уходит |
+|---------|-------|--------------------|-------------|
+| DEBUG | `d()` | Отладка, трассировка, временные логи | Logcat (debug build) |
+| INFO | `i()` | Значимые события (навигация, загрузка данных) | Logcat (debug build) |
+| WARNING | `w()` | Проблема, но приложение работает | Crashlytics breadcrumb |
+| ERROR | `e()` | Критическая ошибка, неожиданное состояние | Crashlytics non-fatal exception |
+
+Иерархия: DEBUG < INFO < WARNING < ERROR. Sink получает только сообщения `>= minLevel`.
+
+## Теги
+
+### Формат
+
+`###СЛОВО###` — тройные решётки, БОЛЬШИЕ буквы. Слово = область/модуль, не имя класса.
+
+### Константы
+
+Каждый модуль имеет `LogTags.kt`:
+
+```kotlin
+package me.apomazkin.stattab
+
+object LogTags {
+    const val STAT = "###STAT###"
+}
+```
+
+**Использовать ТОЛЬКО константы. НЕ хардкодить строки.**
+
+### Таблица тегов
+
+| Модуль | Константа | Значение |
+|--------|-----------|----------|
+| core/mate | `LogTags.MATE` | `###MATE###` |
+| core/ui | `LogTags.UI` | `###UI###` |
+| screen/dictionaryTab | `LogTags.VOCAB` | `###VOCAB###` |
+| screen/dictionary | `LogTags.DICT` | `###DICT###` |
+| screen/quiztab | `LogTags.QUIZ` | `###QUIZ###` |
+| screen/quiz/chat | `LogTags.CHAT` | `###CHAT###` |
+| screen/stattab | `LogTags.STAT` | `###STAT###` |
+| screen/settingstab | `LogTags.SETTINGS`, `LogTags.WEBVIEW` | `###SETTINGS###`, `###WEBVIEW###` |
+| screen/wordcard | `LogTags.WORDCARD` | `###WORDCARD###` |
+| widget/dictionaryappbar | `LogTags.APPBAR` | `###APPBAR###` |
+| app | `LogTags.APP` | `###APP###` |
+| core-db-impl | `LogTags.DB` | `###DB###` |
+
+Новый модуль = создай `LogTags.kt` с константой.
+
+## Правила вызова
+
+```kotlin
+// Правильно:
+logger.d(tag = LogTags.MATE, message = "RunEffect: $effect")
+logger.w(tag = LogTags.SETTINGS, message = "navigate: privacy_policy")
+logger.e(tag = LogTags.APP, message = "unknown pageKey: $pageKey")
+
+// ЗАПРЕЩЕНО:
+logger.d(tag = "###MATE###", message = "...")   // хардкод строки
+logger.d(message = "...")                        // без тега
+android.util.Log.d("TAG", "message")            // прямой Log
+if (BuildConfig.DEBUG) { logger.d(...) }         // обёртка (фильтрация в sink)
+```
+
+- `tag` обязателен — не полагайся на дефолт `###LEXEME###`
+- Сообщение лаконичное с контекстом: `"action: data"` 
+- `if (BuildConfig.DEBUG)` — НЕ НУЖЕН, фильтрация на уровне sink'ов
+- Прокидывание logger: через конструктор (DI `@Inject` или параметр)
+
+## Расширение
+
+Добавить новый sink (файл, аналитика, remote):
+1. Создать класс `class MySink(override val minLevel: LogLevel) : LogSink`
+2. Добавить `buildConfigField` в `app/build.gradle.kts`
+3. Зарегистрировать в `LoggerModule.provideSinks()`

--- a/modules/core/mate/src/main/java/me/apomazkin/mate/LogTags.kt
+++ b/modules/core/mate/src/main/java/me/apomazkin/mate/LogTags.kt
@@ -1,0 +1,5 @@
+package me.apomazkin.mate
+
+object LogTags {
+    const val MATE = "###MATE###"
+}

--- a/modules/core/ui/src/main/java/me/apomazkin/ui/LogTags.kt
+++ b/modules/core/ui/src/main/java/me/apomazkin/ui/LogTags.kt
@@ -1,0 +1,5 @@
+package me.apomazkin.ui
+
+object LogTags {
+    const val UI = "###UI###"
+}

--- a/modules/core/ui/src/main/java/me/apomazkin/ui/logger/LexemeLogger.kt
+++ b/modules/core/ui/src/main/java/me/apomazkin/ui/logger/LexemeLogger.kt
@@ -1,5 +1,10 @@
 package me.apomazkin.ui.logger
 
 interface LexemeLogger {
-    fun log(tag: String = "##MATE##", message: String)
+    fun log(level: LogLevel = LogLevel.DEBUG, tag: String = "###LEXEME###", message: String)
+
+    fun d(tag: String = "###LEXEME###", message: String) = log(LogLevel.DEBUG, tag, message)
+    fun i(tag: String = "###LEXEME###", message: String) = log(LogLevel.INFO, tag, message)
+    fun w(tag: String = "###LEXEME###", message: String) = log(LogLevel.WARNING, tag, message)
+    fun e(tag: String = "###LEXEME###", message: String) = log(LogLevel.ERROR, tag, message)
 }

--- a/modules/core/ui/src/main/java/me/apomazkin/ui/logger/LogLevel.kt
+++ b/modules/core/ui/src/main/java/me/apomazkin/ui/logger/LogLevel.kt
@@ -1,0 +1,3 @@
+package me.apomazkin.ui.logger
+
+enum class LogLevel { DEBUG, INFO, WARNING, ERROR }

--- a/modules/core/ui/src/main/java/me/apomazkin/ui/logger/LogSink.kt
+++ b/modules/core/ui/src/main/java/me/apomazkin/ui/logger/LogSink.kt
@@ -1,0 +1,6 @@
+package me.apomazkin.ui.logger
+
+interface LogSink {
+    val minLevel: LogLevel
+    fun write(level: LogLevel, tag: String, message: String)
+}

--- a/modules/screen/dictionary/src/main/java/me/apomazkin/dictionary/LogTags.kt
+++ b/modules/screen/dictionary/src/main/java/me/apomazkin/dictionary/LogTags.kt
@@ -1,0 +1,5 @@
+package me.apomazkin.dictionary
+
+object LogTags {
+    const val DICT = "###DICT###"
+}

--- a/modules/screen/dictionaryTab/src/main/java/me/apomazkin/dictionarytab/LogTags.kt
+++ b/modules/screen/dictionaryTab/src/main/java/me/apomazkin/dictionarytab/LogTags.kt
@@ -1,0 +1,5 @@
+package me.apomazkin.dictionarytab
+
+object LogTags {
+    const val VOCAB = "###VOCAB###"
+}

--- a/modules/screen/dictionaryTab/src/main/java/me/apomazkin/dictionarytab/logic/DatasourceEffectHandler.kt
+++ b/modules/screen/dictionaryTab/src/main/java/me/apomazkin/dictionarytab/logic/DatasourceEffectHandler.kt
@@ -1,6 +1,5 @@
 package me.apomazkin.dictionarytab.logic
 
-import android.util.Log
 import androidx.paging.cachedIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -9,12 +8,13 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import me.apomazkin.dictionarytab.BuildConfig
 import me.apomazkin.dictionarytab.deps.DictionaryTabUseCase
 import me.apomazkin.dictionarytab.entity.WordInfo
 import me.apomazkin.mate.EMPTY_STRING
 import me.apomazkin.mate.Effect
 import me.apomazkin.mate.MateFlowHandler
+import me.apomazkin.mate.LogTags
+import me.apomazkin.ui.logger.LexemeLogger
 
 /**
  * Effect
@@ -46,6 +46,7 @@ internal sealed interface DatasourceEffect : Effect {
 internal class DatasourceEffectHandler(
         private val dictionaryTabUseCase: DictionaryTabUseCase,
         private val scope: CoroutineScope,
+        private val logger: LexemeLogger,
 ) : MateFlowHandler<Msg, Effect> {
 
     override var job: Job? = null
@@ -62,16 +63,9 @@ internal class DatasourceEffectHandler(
             effect: Effect,
             consumer: (Msg) -> Unit,
     ) {
-        //TODO kilg 14.06.2025 00:48
-        // https://github.com/KilgoreT/PolyTrainer/issues/372
-        if (BuildConfig.DEBUG) {
-            Log.d("##MATE##", "RunEffect: $effect")
-        }
+        logger.d(tag = LogTags.MATE, message = "RunEffect: $effect")
         return when (val eff = effect as? DatasourceEffect) {
 
-            //TODO kilg 25.05.2025 03:16 В префах хранить именно id текущего языка,
-            // а не numericCode. И вообще, кешировать бы его, а не запрашивать каждый раз.
-            // https://github.com/KilgoreT/PolyTrainer/issues/369
             is DatasourceEffect.LoadTermFlow -> {
                 withContext(Dispatchers.IO) {
                     val dictionaryId = dictionaryTabUseCase.getCurrentDict().id.toInt()

--- a/modules/screen/dictionaryTab/src/main/java/me/apomazkin/dictionarytab/ui/DictionaryTabViewModel.kt
+++ b/modules/screen/dictionaryTab/src/main/java/me/apomazkin/dictionarytab/ui/DictionaryTabViewModel.kt
@@ -29,6 +29,7 @@ class DictionaryTabViewModel(
             DatasourceEffectHandler(
                     dictionaryTabUseCase = dictionaryTabUseCase,
                     scope = viewModelScope,
+                    logger = logger,
             ),
             UiEffectHandler()
         )

--- a/modules/screen/dictionaryTab/src/test/java/me/apomazkin/dictionarytab/logic/VocabularyTabReducerKtTest.kt
+++ b/modules/screen/dictionaryTab/src/test/java/me/apomazkin/dictionarytab/logic/VocabularyTabReducerKtTest.kt
@@ -42,7 +42,7 @@ class VocabularyTabReducerKtTest {
 
     private val reducer = VocabularyTabReducer(
         logger = object : LexemeLogger {
-            override fun log(tag: String, message: String) {}
+            override fun log(level: me.apomazkin.ui.logger.LogLevel, tag: String, message: String) {}
         }
     )
 

--- a/modules/screen/main/src/main/java/me/apomazkin/main/Settings.kt
+++ b/modules/screen/main/src/main/java/me/apomazkin/main/Settings.kt
@@ -1,6 +1,5 @@
 package me.apomazkin.main
 
-import android.util.Log
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -37,7 +36,6 @@ fun NavGraphBuilder.settings(
         arguments = listOf(navArgument("pageKey") { type = NavType.StringType })
     ) { backStackEntry ->
         val pageKey = backStackEntry.arguments?.getString("pageKey") ?: run {
-            Log.e("Settings", "###WebView### missing pageKey argument")
             return@composable
         }
         mainUiDeps.WebViewScreenDep(

--- a/modules/screen/quiz/chat/src/main/java/me/apomazkin/quiz/chat/ChatViewModel.kt
+++ b/modules/screen/quiz/chat/src/main/java/me/apomazkin/quiz/chat/ChatViewModel.kt
@@ -39,8 +39,10 @@ class ChatViewModel(
                     quizChatUseCase = quizChatUseCase,
                     resourceManager = resourceManager,
                     prefsProvider = prefsProvider,
+                    logger = logger,
                 ),
                 prefsProvider = prefsProvider,
+                logger = logger,
             ),
             AppBarFlowHandler(
                 prefsProvider = prefsProvider,

--- a/modules/screen/quiz/chat/src/main/java/me/apomazkin/quiz/chat/LogTags.kt
+++ b/modules/screen/quiz/chat/src/main/java/me/apomazkin/quiz/chat/LogTags.kt
@@ -1,0 +1,5 @@
+package me.apomazkin.quiz.chat
+
+object LogTags {
+    const val CHAT = "###CHAT###"
+}

--- a/modules/screen/quiz/chat/src/main/java/me/apomazkin/quiz/chat/logic/DatasourceEffectHandler.kt
+++ b/modules/screen/quiz/chat/src/main/java/me/apomazkin/quiz/chat/logic/DatasourceEffectHandler.kt
@@ -1,6 +1,5 @@
 package me.apomazkin.quiz.chat.logic
 
-import android.util.Log
 import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -11,6 +10,8 @@ import me.apomazkin.mate.MateEffectHandler
 import me.apomazkin.prefs.PrefKey
 import me.apomazkin.prefs.PrefsProvider
 import me.apomazkin.quiz.chat.quiz.QuizGame
+import me.apomazkin.mate.LogTags
+import me.apomazkin.ui.logger.LexemeLogger
 import kotlin.random.Random
 
 /**
@@ -39,13 +40,14 @@ internal sealed interface DatasourceEffect : Effect {
 internal class DatasourceEffectHandler(
         private val quizGame: QuizGame,
         private val prefsProvider: PrefsProvider,
+        private val logger: LexemeLogger,
 ) : MateEffectHandler<Msg, Effect> {
 
     override suspend fun runEffect(
             effect: Effect,
             consumer: (Msg) -> Unit,
     ) {
-        Log.d("##MATE##", "RunEffect: $effect")
+        logger.d(tag = LogTags.MATE, message = "RunEffect: $effect")
         val eff = effect as DatasourceEffect
         return when (eff) {
             is DatasourceEffect.PrepareToStart -> {

--- a/modules/screen/quiz/chat/src/main/java/me/apomazkin/quiz/chat/quiz/QuizGameImpl.kt
+++ b/modules/screen/quiz/chat/src/main/java/me/apomazkin/quiz/chat/quiz/QuizGameImpl.kt
@@ -1,6 +1,5 @@
 package me.apomazkin.quiz.chat.quiz
 
-import android.util.Log
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ParagraphStyle
@@ -18,6 +17,8 @@ import me.apomazkin.quiz.chat.entity.WriteQuiz
 import me.apomazkin.quiz.chat.entity.WriteQuizUpsertEntity
 import me.apomazkin.theme.LexemeStyle
 import me.apomazkin.theme.chatCorrectColor
+import me.apomazkin.quiz.chat.LogTags
+import me.apomazkin.ui.logger.LexemeLogger
 import me.apomazkin.ui.resource.ResourceManager
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -28,6 +29,7 @@ class QuizGameImpl(
         private val quizChatUseCase: QuizChatUseCase,
         private val resourceManager: ResourceManager,
         private val prefsProvider: PrefsProvider,
+        private val logger: LexemeLogger,
         private val maxStepInSession: Int = 10,
         private val maxGrade: Int = 3,
         private val maxScoreInGrade: Int = 5,
@@ -273,7 +275,7 @@ class QuizGameImpl(
      */
     private fun addQuizData(quizData: List<QuizItem>) {
         quizList.addAll(quizData)
-        Log.d("###", "<QuizGameImpl.kt>::addQuizData => quiz size = ${quizList.size}")
+        logger.d(tag = LogTags.CHAT, message = "addQuizData: size = ${quizList.size}")
     }
 
     private fun getQuiz(step: Step): QuizItem {

--- a/modules/screen/quiztab/src/main/java/me/apomazkin/quiztab/LogTags.kt
+++ b/modules/screen/quiztab/src/main/java/me/apomazkin/quiztab/LogTags.kt
@@ -1,0 +1,5 @@
+package me.apomazkin.quiztab
+
+object LogTags {
+    const val QUIZ = "###QUIZ###"
+}

--- a/modules/screen/quiztab/src/main/java/me/apomazkin/quiztab/QuizTabViewModel.kt
+++ b/modules/screen/quiztab/src/main/java/me/apomazkin/quiztab/QuizTabViewModel.kt
@@ -25,7 +25,7 @@ class QuizTabViewModel(
         coroutineScope = viewModelScope,
         reducer = QuizTabReducer(logger = logger),
         effectHandlerSet = setOf(
-            DatasourceEffectHandler(quizTabUseCase = quizTabUseCase),
+            DatasourceEffectHandler(quizTabUseCase = quizTabUseCase, logger = logger),
             UiEffectHandler()
         )
     )

--- a/modules/screen/quiztab/src/main/java/me/apomazkin/quiztab/logic/DatasourceEffectHandler.kt
+++ b/modules/screen/quiztab/src/main/java/me/apomazkin/quiztab/logic/DatasourceEffectHandler.kt
@@ -1,9 +1,10 @@
 package me.apomazkin.quiztab.logic
 
-import android.util.Log
 import me.apomazkin.mate.Effect
 import me.apomazkin.mate.MateEffectHandler
 import me.apomazkin.quiztab.deps.QuizTabUseCase
+import me.apomazkin.mate.LogTags
+import me.apomazkin.ui.logger.LexemeLogger
 
 /**
  * Effect
@@ -16,13 +17,14 @@ internal sealed interface DatasourceEffect : Effect {
  */
 internal class DatasourceEffectHandler(
     private val quizTabUseCase: QuizTabUseCase,
+    private val logger: LexemeLogger,
 ) : MateEffectHandler<Msg, Effect> {
     
     override suspend fun runEffect(
         effect: Effect,
         consumer: (Msg) -> Unit
     ) {
-        Log.d("##MATE##", "RunEffect: $effect")
+        logger.d(tag = LogTags.MATE, message = "RunEffect: $effect")
         return when (val eff = effect as? DatasourceEffect) {
             null -> Msg.Empty
             else -> Msg.Empty

--- a/modules/screen/settingstab/src/main/java/me/apomazkin/settingstab/LogTags.kt
+++ b/modules/screen/settingstab/src/main/java/me/apomazkin/settingstab/LogTags.kt
@@ -1,0 +1,6 @@
+package me.apomazkin.settingstab
+
+object LogTags {
+    const val SETTINGS = "###SETTINGS###"
+    const val WEBVIEW = "###WEBVIEW###"
+}

--- a/modules/screen/settingstab/src/main/java/me/apomazkin/settingstab/SettingsTabViewModel.kt
+++ b/modules/screen/settingstab/src/main/java/me/apomazkin/settingstab/SettingsTabViewModel.kt
@@ -25,7 +25,7 @@ class SettingsTabViewModel(
         coroutineScope = viewModelScope,
         reducer = SettingsTabReducer(logger = logger),
         effectHandlerSet = setOf(
-            DatasourceEffectHandler(settingsTabUseCase),
+            DatasourceEffectHandler(settingsTabUseCase, logger = logger),
             UiEffectHandler()
         )
     )

--- a/modules/screen/settingstab/src/main/java/me/apomazkin/settingstab/WebViewScreen.kt
+++ b/modules/screen/settingstab/src/main/java/me/apomazkin/settingstab/WebViewScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.activity.compose.BackHandler
 import androidx.compose.ui.viewinterop.AndroidView
+import me.apomazkin.settingstab.LogTags
 import me.apomazkin.ui.logger.LexemeLogger
 
 private const val ALLOWED_DOMAIN = "kilgoret.github.io"
@@ -49,7 +50,7 @@ fun WebViewScreen(
     var isError by remember { mutableStateOf(false) }
 
     BackHandler {
-        logger.log(tag = "###WebView###", message = "back: $pageKey")
+        logger.log(tag = LogTags.WEBVIEW, message = "back: $pageKey")
         onBackPress()
     }
 
@@ -58,7 +59,7 @@ fun WebViewScreen(
             WebViewAppBar(
                 title = title,
                 onBackPress = {
-                    logger.log(tag = "###WebView###", message = "back: $pageKey")
+                    logger.log(tag = LogTags.WEBVIEW, message = "back: $pageKey")
                     onBackPress()
                 },
             )
@@ -78,7 +79,7 @@ fun WebViewScreen(
             if (isError) {
                 ErrorContent(
                     onRetry = {
-                        logger.log(tag = "###WebView###", message = "retry: $url")
+                        logger.log(tag = LogTags.WEBVIEW, message = "retry: $url")
                         isError = false
                         isLoading = true
                     }
@@ -88,7 +89,7 @@ fun WebViewScreen(
                 AndroidView(
                     modifier = Modifier.fillMaxSize(),
                     onRelease = { webView ->
-                        logger.log(tag = "###WebView###", message = "destroy: $url")
+                        logger.log(tag = LogTags.WEBVIEW, message = "destroy: $url")
                         webView.stopLoading()
                         webView.destroy()
                     },
@@ -102,7 +103,7 @@ fun WebViewScreen(
                                     loadingUrl: String?,
                                     favicon: Bitmap?
                                 ) {
-                                    logger.log(tag = "###WebView###", message = "loading: $loadingUrl")
+                                    logger.log(tag = LogTags.WEBVIEW, message = "loading: $loadingUrl")
                                     isLoading = true
                                     isError = false
                                 }
@@ -111,7 +112,7 @@ fun WebViewScreen(
                                     view: WebView?,
                                     finishedUrl: String?
                                 ) {
-                                    logger.log(tag = "###WebView###", message = "loaded: $finishedUrl")
+                                    logger.log(tag = LogTags.WEBVIEW, message = "loaded: $finishedUrl")
                                     isLoading = false
                                 }
 
@@ -121,7 +122,7 @@ fun WebViewScreen(
                                     error: WebResourceError?
                                 ) {
                                     if (request?.isForMainFrame == true) {
-                                        logger.log(tag = "###WebView###", message = "error: $url")
+                                        logger.log(tag = LogTags.WEBVIEW, message = "error: $url")
                                         isLoading = false
                                         isError = true
                                     }
@@ -133,7 +134,7 @@ fun WebViewScreen(
                                     errorResponse: android.webkit.WebResourceResponse?
                                 ) {
                                     if (request?.isForMainFrame == true) {
-                                        logger.log(tag = "###WebView###", message = "http error: ${errorResponse?.statusCode} $url")
+                                        logger.log(tag = LogTags.WEBVIEW, message = "http error: ${errorResponse?.statusCode} $url")
                                         isLoading = false
                                         isError = true
                                     }

--- a/modules/screen/settingstab/src/main/java/me/apomazkin/settingstab/logic/DatasourceEffectHandler.kt
+++ b/modules/screen/settingstab/src/main/java/me/apomazkin/settingstab/logic/DatasourceEffectHandler.kt
@@ -1,12 +1,13 @@
 package me.apomazkin.settingstab.logic
 
 import android.net.Uri
-import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.apomazkin.mate.Effect
 import me.apomazkin.mate.MateEffectHandler
 import me.apomazkin.settingstab.deps.SettingsTabUseCase
+import me.apomazkin.mate.LogTags
+import me.apomazkin.ui.logger.LexemeLogger
 
 /**
  * Effect
@@ -20,14 +21,15 @@ internal sealed interface DatasourceEffect : Effect {
  * EffectHandler for datastore calls.
  */
 internal class DatasourceEffectHandler(
-    private val settingsTabUseCase: SettingsTabUseCase
+    private val settingsTabUseCase: SettingsTabUseCase,
+    private val logger: LexemeLogger,
 ) : MateEffectHandler<Msg, Effect> {
     
     override suspend fun runEffect(
         effect: Effect,
         consumer: (Msg) -> Unit
     ) {
-        Log.d("##MATE##", "RunEffect: $effect")
+        logger.d(tag = LogTags.MATE, message = "RunEffect: $effect")
         return when (val eff = effect as? DatasourceEffect) {
             is DatasourceEffect.ExportData -> {
                 withContext(Dispatchers.IO) {

--- a/modules/screen/stattab/src/main/java/me/apomazkin/stattab/LogTags.kt
+++ b/modules/screen/stattab/src/main/java/me/apomazkin/stattab/LogTags.kt
@@ -1,0 +1,5 @@
+package me.apomazkin.stattab
+
+object LogTags {
+    const val STAT = "###STAT###"
+}

--- a/modules/screen/stattab/src/main/java/me/apomazkin/stattab/StatisticViewModel.kt
+++ b/modules/screen/stattab/src/main/java/me/apomazkin/stattab/StatisticViewModel.kt
@@ -26,6 +26,7 @@ class StatisticViewModel(
             effectHandlerSet = setOf(
                     DatasourceEffectHandler(
                             useCase = statisticUseCase,
+                            logger = logger,
                     ),
             )
     )

--- a/modules/screen/stattab/src/main/java/me/apomazkin/stattab/mate/DatasourceEffectHandler.kt
+++ b/modules/screen/stattab/src/main/java/me/apomazkin/stattab/mate/DatasourceEffectHandler.kt
@@ -1,6 +1,5 @@
 package me.apomazkin.stattab.mate
 
-import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
@@ -9,6 +8,8 @@ import kotlinx.coroutines.launch
 import me.apomazkin.mate.Effect
 import me.apomazkin.mate.MateFlowHandler
 import me.apomazkin.stattab.deps.StatisticUseCase
+import me.apomazkin.mate.LogTags
+import me.apomazkin.ui.logger.LexemeLogger
 
 /**
  * Effect
@@ -21,6 +22,7 @@ internal sealed interface DatasourceEffect : Effect {
  */
 internal class DatasourceEffectHandler(
     private val useCase: StatisticUseCase,
+    private val logger: LexemeLogger,
 ) : MateFlowHandler<Msg, Effect> {
 
     override var job: Job? = null
@@ -47,7 +49,7 @@ internal class DatasourceEffectHandler(
         effect: Effect,
         consumer: (Msg) -> Unit
     ) {
-        Log.d("##MATE##", "RunEffect: $effect")
+        logger.d(tag = LogTags.MATE, message = "RunEffect: $effect")
         return when (val eff = effect as? DatasourceEffect) {
 
             null -> Msg.Empty

--- a/modules/screen/wordcard/src/main/java/me/apomazkin/wordcard/LogTags.kt
+++ b/modules/screen/wordcard/src/main/java/me/apomazkin/wordcard/LogTags.kt
@@ -1,0 +1,5 @@
+package me.apomazkin.wordcard
+
+object LogTags {
+    const val WORDCARD = "###WORDCARD###"
+}

--- a/modules/widget/dictionaryappbar/src/main/java/me/apomazkin/dictionaryappbar/DictionaryAppBarViewModel.kt
+++ b/modules/widget/dictionaryappbar/src/main/java/me/apomazkin/dictionaryappbar/DictionaryAppBarViewModel.kt
@@ -25,7 +25,8 @@ class DictionaryAppBarViewModel(
             reducer = DictionaryAppBarReducer(logger = logger),
             effectHandlerSet = setOf(
                     DatasourceEffectHandler(
-                            useCase = useCase
+                            useCase = useCase,
+                            logger = logger,
                     )
             )
     )

--- a/modules/widget/dictionaryappbar/src/main/java/me/apomazkin/dictionaryappbar/LogTags.kt
+++ b/modules/widget/dictionaryappbar/src/main/java/me/apomazkin/dictionaryappbar/LogTags.kt
@@ -1,0 +1,5 @@
+package me.apomazkin.dictionaryappbar
+
+object LogTags {
+    const val APPBAR = "###APPBAR###"
+}

--- a/modules/widget/dictionaryappbar/src/main/java/me/apomazkin/dictionaryappbar/mate/DatasourceEffectHandler.kt
+++ b/modules/widget/dictionaryappbar/src/main/java/me/apomazkin/dictionaryappbar/mate/DatasourceEffectHandler.kt
@@ -1,6 +1,5 @@
 package me.apomazkin.dictionaryappbar.mate
 
-import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -12,6 +11,8 @@ import me.apomazkin.dictionaryappbar.deps.DictionaryAppBarUseCase
 import me.apomazkin.dictionarypicker.entity.DictUiEntity
 import me.apomazkin.mate.Effect
 import me.apomazkin.mate.MateFlowHandler
+import me.apomazkin.mate.LogTags
+import me.apomazkin.ui.logger.LexemeLogger
 
 /**
  * Effect
@@ -25,6 +26,7 @@ internal sealed interface DatasourceEffect : Effect {
  */
 internal class DatasourceEffectHandler(
         private val useCase: DictionaryAppBarUseCase,
+        private val logger: LexemeLogger,
 ) : MateFlowHandler<Msg, Effect> {
 
     override var job: Job? = null
@@ -47,7 +49,7 @@ internal class DatasourceEffectHandler(
             effect: Effect,
             consumer: (Msg) -> Unit,
     ) {
-        Log.d("##MATE##", "RunEffect: $effect")
+        logger.d(tag = LogTags.MATE, message = "RunEffect: $effect")
         return when (val eff = effect as? DatasourceEffect) {
             is DatasourceEffect.ChangeDict -> {
                 withContext(Dispatchers.IO) {


### PR DESCRIPTION
## Summary
- Sink pattern: Logger dispatches to List<LogSink>, each sink filters by minLevel
- LogcatSink (debug) + CrashlyticsSink (release: WARNING→breadcrumb, ERROR→non-fatal)
- Log levels: DEBUG < INFO < WARNING < ERROR, configurable per build type
- Gradle property override: `./gradlew assembleRelease -PLOG_LEVEL=DEBUG`
- LogTags.kt per module — all tags as constants, no hardcoded strings
- Migration: all `android.util.Log` removed from source (only in LogcatSink)
- Logging guide: `docs/guides/logging.md`

Closes #451

## Test plan
- [x] Debug build: logs visible in Logcat with correct levels
- [x] All tests pass
- [x] Lint clean
- [x] No `android.util.Log` outside LogcatSink