### PR TITLE
IS455. CI: disable Google Play upload in prerelease pipeline

### DIFF
--- a/.github/workflows/on_prerelease.yml
+++ b/.github/workflows/on_prerelease.yml
@@ -119,15 +119,15 @@ jobs:
             app/build/outputs/apk/release/app-release.apk
             app/build/outputs/bundle/release/app-release.aab
 
-      - name: Upload to Google Play Internal
-        uses: r0adkll/upload-google-play@v1.0.15
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
-          packageName: ${{ secrets.APP_PACKAGE_NAME }}
-          releaseFiles: app/build/outputs/bundle/release/app-release.aab
-          track: internal
-          # whatsNewDirectory: distribution/whatsnew
-          # mappingFile: app/build/outputs/mapping/release/mapping.txt
+#      - name: Upload to Google Play Internal
+#        uses: r0adkll/upload-google-play@v1.0.15
+#        with:
+#          serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+#          packageName: ${{ secrets.APP_PACKAGE_NAME }}
+#          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+#          track: internal
+#          # whatsNewDirectory: distribution/whatsnew
+#          # mappingFile: app/build/outputs/mapping/release/mapping.txt
 
 
 #      - name: Upload AAB


### PR DESCRIPTION
## Summary
- Commented out Google Play Internal upload step in `on_prerelease.yml`
- Prerelease still builds APK+AAB and uploads to GitHub Releases

Closes #455