### PR TITLE
IS459. Remove AD_ID permission from manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 
     <application
         android:name=".App"


### PR DESCRIPTION
## Summary
- Remove transitive `com.google.android.gms.permission.AD_ID` from merged manifest via `tools:node="remove"`
- No ads in the app, AD_ID not needed

Closes #459