### PR TITLE
IS467. Fix publish: remove unsupported params, add debug listing

### DIFF
--- a/.github/workflows/on_prerelease.yml
+++ b/.github/workflows/on_prerelease.yml
@@ -119,9 +119,8 @@ jobs:
         with:
           name: release-artifacts
           path: |
-            app/build/outputs/bundle/release/app-release.aab
-            app/build/outputs/mapping/release/mapping.txt
-            app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
+            app/build/outputs/bundle/release/
+            app/build/outputs/mapping/release/
 
   publish_job:
     name: Publish
@@ -141,6 +140,9 @@ jobs:
           name: release-artifacts
           path: artifacts
 
+      - name: List artifacts
+        run: find artifacts -type f
+
       - name: Upload to Google Play
         uses: r0adkll/upload-google-play@v1.0.15
         with:
@@ -151,5 +153,3 @@ jobs:
           track: alpha
           whatsNewDirectory: distribution/whatsnew
           mappingFile: artifacts/app/build/outputs/mapping/release/mapping.txt
-          debugSymbols: artifacts/app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
-          changesNotSentForReview: true


### PR DESCRIPTION
## Summary
- Remove `debugSymbols` and `changesNotSentForReview` (not supported in v1.0.15)
- Add `find artifacts` step to debug artifact paths
- Fix upload-artifact paths (directories instead of specific files)

Relates to #467