### PR TITLE
IS474. PrefsProvider: nullable Flow for getLongFlow/getIntFlow

### DIFF
--- a/app/src/main/java/me/apomazkin/polytrainer/di/module/dictionarytab/DictionaryTabUseCaseImpl.kt
+++ b/app/src/main/java/me/apomazkin/polytrainer/di/module/dictionarytab/DictionaryTabUseCaseImpl.kt
@@ -55,9 +55,8 @@ class DictionaryTabUseCaseImpl @Inject constructor(
 
     override fun flowCurrentDict(): Flow<DictUiEntity> = prefsProvider
         .getLongFlow(PrefKey.CURRENT_DICTIONARY_ID_LONG)
-        .map { id: Long ->
-            val dict = (dictionaryApi
-                .getDictionaryById(id)
+        .map { id: Long? ->
+            val dict = (id?.let { dictionaryApi.getDictionaryById(it) }
                 ?: dictionaryApi.getDictionaryList().firstOrNull())
                 ?.let { dict ->
                     DictUiEntity(

--- a/app/src/main/java/me/apomazkin/polytrainer/di/module/statistictab/StatisticUseCaseImpl.kt
+++ b/app/src/main/java/me/apomazkin/polytrainer/di/module/statistictab/StatisticUseCaseImpl.kt
@@ -22,8 +22,7 @@ class StatisticUseCaseImpl @Inject constructor(
         val dictionaryIdFlow: Flow<Int?> = prefsProvider
                 .getLongFlow(PrefKey.CURRENT_DICTIONARY_ID_LONG)
                 .mapLatest { id ->
-                    val dictionaryId = dictionaryApi
-                            .getDictionaryById(id)?.id?.toInt()
+                    val dictionaryId = id?.let { dictionaryApi.getDictionaryById(it)?.id?.toInt() }
                             ?: dictionaryApi.getDictionaryList().firstOrNull()?.id?.toInt()
                     dictionaryId
                 }
@@ -38,8 +37,7 @@ class StatisticUseCaseImpl @Inject constructor(
         val dictionaryIdFlow: Flow<Int?> = prefsProvider
                 .getLongFlow(PrefKey.CURRENT_DICTIONARY_ID_LONG)
                 .mapLatest { id ->
-                    val dictionaryId = dictionaryApi
-                            .getDictionaryById(id)?.id?.toInt()
+                    val dictionaryId = id?.let { dictionaryApi.getDictionaryById(it)?.id?.toInt() }
                             ?: dictionaryApi.getDictionaryList().firstOrNull()?.id?.toInt()
                     dictionaryId
                 }
@@ -54,8 +52,7 @@ class StatisticUseCaseImpl @Inject constructor(
         val dictionaryIdFlow: Flow<Int?> = prefsProvider
             .getLongFlow(PrefKey.CURRENT_DICTIONARY_ID_LONG)
             .mapLatest { id ->
-                val dictionaryId = dictionaryApi
-                    .getDictionaryById(id)?.id?.toInt()
+                val dictionaryId = id?.let { dictionaryApi.getDictionaryById(it)?.id?.toInt() }
                     ?: dictionaryApi.getDictionaryList().firstOrNull()?.id?.toInt()
                 dictionaryId
             }

--- a/app/src/test/java/me/apomazkin/polytrainer/di/module/widget/DictionaryAppBarUseCaseImplTest.kt
+++ b/app/src/test/java/me/apomazkin/polytrainer/di/module/widget/DictionaryAppBarUseCaseImplTest.kt
@@ -53,7 +53,7 @@ class DictionaryAppBarUseCaseImplTest {
     private val dictNoFlag =
         DictionaryApiEntity(id = 3L, numericCode = null, name = "Biology", addDate = now)
 
-    private lateinit var prefsFlow: MutableStateFlow<Long>
+    private lateinit var prefsFlow: MutableStateFlow<Long?>
     private lateinit var dictListFlow: MutableStateFlow<List<DictionaryApiEntity>>
 
     @Before
@@ -194,5 +194,17 @@ class DictionaryAppBarUseCaseImplTest {
         useCase.changeDict(42L)
 
         io.mockk.coVerify { prefsProvider.setLong(PrefKey.CURRENT_DICTIONARY_ID_LONG, 42L) }
+    }
+
+    // === null prefs ID ===
+
+    @Test
+    fun `flowCurrentDict falls back to first dict when prefs ID is null`() = runTest {
+        prefsFlow.value = null
+
+        val result = useCase.flowCurrentDict().first()
+
+        assertEquals(dictEn.id, result.id)
+        assertEquals("English", result.title)
     }
 }

--- a/docs/crashes/2026-05-09_prefs-key-not-found.md
+++ b/docs/crashes/2026-05-09_prefs-key-not-found.md
@@ -1,0 +1,25 @@
+# Crash: PrefsProvider — PrefKey not found
+
+**Дата:** 2026-05-09 14:00:32
+**Версия:** 0.1.3 (10003)
+**Issue ID:** 49b00709a9ed3843be4f282c96b9e1d0
+
+## Fatal Exception
+
+```
+java.lang.IllegalStateException: PrefKey CURRENT_DICTIONARY_ID_LONG not found
+    at me.apomazkin.prefs.PrefsProvider$getLongFlow$$inlined$map$1$2.emit(PrefsProvider.java:225)
+    at kotlinx.coroutines.flow.internal.SafeCollectorKt$emitFun$1.invoke(SafeCollector.kt:11)
+    at kotlinx.coroutines.flow.internal.SafeCollector.emit(SafeCollector.kt:113)
+    at androidx.datastore.core.DataStoreImpl$data$1.invokeSuspend(DataStoreImpl.kt:74)
+    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
+    at android.os.Handler.handleCallback(Handler.java:938)
+    at android.os.Looper.loop(Looper.java:223)
+    at android.app.ActivityThread.main(ActivityThread.java:7680)
+```
+
+## Описание
+
+`PrefsProvider.getLongFlow()` бросает `IllegalStateException` когда ключ `CURRENT_DICTIONARY_ID_LONG` не найден в DataStore. Происходит при первом запуске или после очистки данных — DataStore пуст, ключ ещё не записан. Flow эмитит данные без этого ключа, и маппинг бросает exception вместо возврата null/default.
+
+Проблема в `PrefsProvider.getLongFlow()` — вероятно `map` блок ожидает что ключ существует и бросает exception если его нет.

--- a/docs/features/IS474_prefs_key_not_found/00_task.md
+++ b/docs/features/IS474_prefs_key_not_found/00_task.md
@@ -1,0 +1,42 @@
+# Task
+
+## IS474. Crash: PrefsProvider throws when PrefKey not found
+
+Краш в продакшне. Версия 0.1.3.
+
+## Стектрейс
+
+```
+java.lang.IllegalStateException: PrefKey CURRENT_DICTIONARY_ID_LONG not found
+    at me.apomazkin.prefs.PrefsProvider$getLongFlow$$inlined$map$1$2.emit
+    at androidx.datastore.core.DataStoreImpl$data$1.invokeSuspend
+```
+
+## Суть
+
+`PrefsProvider.getLongFlow()` (строка 42) бросает `IllegalStateException` когда ключ не найден в DataStore:
+
+```kotlin
+fun getLongFlow(prefKey: PrefKey): Flow<Long> {
+    return context.dataStore.data
+        .map {
+            it[longPreferencesKey(prefKey.value)]
+                ?: throw IllegalStateException("PrefKey $prefKey not found")
+        }
+}
+```
+
+Происходит при первом запуске или чистых данных — ключ `CURRENT_DICTIONARY_ID_LONG` ещё не записан.
+
+## Непоследовательность
+
+| Метод | Поведение при отсутствии ключа |
+|-------|-------------------------------|
+| `getIntFlow()` | `throw IllegalStateException` ← краш |
+| `getLongFlow()` | `throw IllegalStateException` ← краш |
+| `getBooleanFlow()` | `?: false` ← дефолт, безопасно |
+| `getInt()` | `return null` ← безопасно |
+| `getLong()` | `return null` ← безопасно |
+| `getBoolean()` | `return null` ← безопасно |
+
+Flow-версии Int и Long крашат, все остальные — безопасны.

--- a/docs/features/IS474_prefs_key_not_found/01_solution.md
+++ b/docs/features/IS474_prefs_key_not_found/01_solution.md
@@ -1,0 +1,96 @@
+# Solution: IS474 — PrefsProvider throws on missing key
+
+## Анализ вызовов
+
+`getLongFlow(CURRENT_DICTIONARY_ID_LONG)` вызывается в:
+
+| Файл | Использование |
+|------|--------------|
+| DictionaryAppBarUseCaseImpl:34 | `combine(prefsProvider.getLongFlow(...), ...)` — реактивное обновление AppBar |
+| DictionaryTabUseCaseImpl:57 | `.getLongFlow(...)` — текущий словарь для списка |
+| StatisticUseCaseImpl:23,39,55 | `.getLongFlow(...)` — текущий словарь для статистики |
+
+Все подписываются через `combine`/`flatMapLatest`. При первом запуске ключ не существует → exception → краш.
+
+`getIntFlow()` нигде не вызывается — но содержит ту же проблему.
+
+## Варианты
+
+### Вариант A: Nullable Flow
+
+```kotlin
+fun getLongFlow(prefKey: PrefKey): Flow<Long?> {
+    return context.dataStore.data
+        .map { it[longPreferencesKey(prefKey.value)] }
+}
+```
+
+Flow эмитит `null` когда ключ отсутствует. Потребители сами решают что делать.
+
+| | |
+|---|---|
+| Плюсы | Честный API — ключ может не существовать, и это ок |
+| Минусы | Все 5 call sites нужно обновить — обработать null. Ломает текущий контракт `Flow<Long>` → `Flow<Long?>` |
+| Сложность | MEDIUM |
+
+### Вариант B: Default value
+
+```kotlin
+fun getLongFlow(prefKey: PrefKey, default: Long = -1L): Flow<Long> {
+    return context.dataStore.data
+        .map { it[longPreferencesKey(prefKey.value)] ?: default }
+}
+```
+
+Возвращает дефолт когда ключ отсутствует. Аналогично `getBooleanFlow` (уже использует `?: false`).
+
+| | |
+|---|---|
+| Плюсы | Не ломает контракт `Flow<Long>`. Потребители не меняются если дефолт подходит |
+| Минусы | Magic value `-1L` — неочевидно. Для dictionary ID нет "правильного" дефолта |
+| Сложность | LOW |
+
+### Вариант C: filterNotNull
+
+```kotlin
+fun getLongFlow(prefKey: PrefKey): Flow<Long> {
+    return context.dataStore.data
+        .map { it[longPreferencesKey(prefKey.value)] }
+        .filterNotNull()
+}
+```
+
+Flow не эмитит пока ключ не записан. Первый emit — когда ключ появится.
+
+| | |
+|---|---|
+| Плюсы | Не ломает контракт. Не крашит. Нет magic value. Потребители просто "ждут" данных |
+| Минусы | При первом запуске UI может висеть без данных пока ключ не появится. Но SplashScreen уже устанавливает dictionary — к моменту подписки ключ обычно есть |
+| Сложность | LOW |
+
+## Рекомендация: Вариант A (Nullable Flow)
+
+Обоснование:
+
+1. **Честный API** — ключ может не существовать, и Flow это отражает через `null`
+2. **Потребители явно обрабатывают null** — fallback на первый словарь, не тихое зависание UI
+3. **Вариант C отклонён** — filterNotNull() маскирует отсутствие ключа, UI зависает без данных и без индикации
+4. **Одинаковый фикс для Int и Long** — `getIntFlow()` фиксится так же
+
+Также: исправить `getIntFlow()` аналогично (та же проблема, строка 24).
+
+## Фикс
+
+```kotlin
+fun getLongFlow(prefKey: PrefKey): Flow<Long?> {
+    return context.dataStore.data
+        .map { it[longPreferencesKey(prefKey.value)] }
+}
+
+fun getIntFlow(prefKey: PrefKey): Flow<Int?> {
+    return context.dataStore.data
+        .map { it[intPreferencesKey(prefKey.value)] }
+}
+```
+
+Удалить `throw IllegalStateException` из обоих методов. Потребители обрабатывают null с fallback.

--- a/docs/features/IS474_prefs_key_not_found/02_design_tree.md
+++ b/docs/features/IS474_prefs_key_not_found/02_design_tree.md
@@ -1,0 +1,174 @@
+# Design Tree: IS474 — PrefsProvider nullable Flow
+
+## Graph
+
+```yaml
+- id: 0
+  file: modules/datasource/prefs/src/main/java/me/apomazkin/prefs/PrefsProvider.kt
+  action: "~"
+  depends: []
+
+- id: 1
+  file: app/src/main/java/me/apomazkin/polytrainer/di/module/widget/DictionaryAppBarUseCaseImpl.kt
+  action: "~"
+  depends: [0]
+
+- id: 2
+  file: app/src/main/java/me/apomazkin/polytrainer/di/module/dictionarytab/DictionaryTabUseCaseImpl.kt
+  action: "~"
+  depends: [0]
+
+- id: 3
+  file: app/src/main/java/me/apomazkin/polytrainer/di/module/statistictab/StatisticUseCaseImpl.kt
+  action: "~"
+  depends: [0]
+
+- id: 4
+  file: app/src/test/java/me/apomazkin/polytrainer/di/module/widget/DictionaryAppBarUseCaseImplTest.kt
+  action: "~"
+  depends: [0]
+```
+
+## Details
+
+### #0 PrefsProvider.kt [~]
+
+Убрать `throw IllegalStateException` из `getLongFlow()` и `getIntFlow()`. Вернуть nullable:
+
+**getLongFlow — было:**
+```kotlin
+fun getLongFlow(prefKey: PrefKey): Flow<Long> {
+    return context.dataStore.data
+        .map {
+            it[longPreferencesKey(prefKey.value)]
+                ?: throw IllegalStateException("PrefKey $prefKey not found")
+        }
+}
+```
+
+**getLongFlow — стало:**
+```kotlin
+fun getLongFlow(prefKey: PrefKey): Flow<Long?> {
+    return context.dataStore.data
+        .map { it[longPreferencesKey(prefKey.value)] }
+}
+```
+
+**getIntFlow — было:**
+```kotlin
+fun getIntFlow(prefKey: PrefKey): Flow<Int> {
+    return context.dataStore.data
+        .map {
+            it[intPreferencesKey(prefKey.value)]
+                ?: throw IllegalStateException("PrefKey $prefKey not found")
+        }
+}
+```
+
+**getIntFlow — стало:**
+```kotlin
+fun getIntFlow(prefKey: PrefKey): Flow<Int?> {
+    return context.dataStore.data
+        .map { it[intPreferencesKey(prefKey.value)] }
+}
+```
+
+`getBooleanFlow` — не трогаем, уже безопасный (`?: false`).
+
+### #1 DictionaryAppBarUseCaseImpl.kt [~]
+
+Строка 34: `combine(prefsProvider.getLongFlow(...), dictionaryListFlow) { id, list -> ... }`
+
+`id` теперь `Long?`. Логика fallback уже есть на строке 37:
+```kotlin
+(list.find { it.id == id } ?: list.firstOrNull())
+```
+
+Когда `id == null` — `list.find { it.id == null }` не найдёт → fallback на `list.firstOrNull()`. Корректно — при null id берём первый словарь.
+
+**Изменение:** только тип в лямбде `{ id: Long?, list -> ... }`. Логика не меняется — fallback работает.
+
+### #2 DictionaryTabUseCaseImpl.kt [~]
+
+Строка 57-58:
+```kotlin
+prefsProvider.getLongFlow(...)
+    .map { id: Long -> ... }
+```
+
+`id` теперь `Long?`. Внутри map вызывается `dictionaryApi.getDictionaryById(id)` — `id` nullable.
+
+**Было:**
+```kotlin
+.map { id: Long ->
+    val dict = (dictionaryApi.getDictionaryById(id) ?: dictionaryApi.getDictionaryList().firstOrNull())
+```
+
+**Стало:**
+```kotlin
+.map { id: Long? ->
+    val dict = (id?.let { dictionaryApi.getDictionaryById(it) } ?: dictionaryApi.getDictionaryList().firstOrNull())
+```
+
+При `id == null` → пропускаем `getDictionaryById`, сразу fallback на первый словарь.
+
+### #3 StatisticUseCaseImpl.kt [~]
+
+Строки 23, 39, 55 — три метода с одинаковым паттерном:
+```kotlin
+prefsProvider.getLongFlow(...)
+    .mapLatest { id ->
+        val dictionaryId = dictionaryApi.getDictionaryById(id)?.id?.toInt()
+            ?: dictionaryApi.getDictionaryList().firstOrNull()?.id?.toInt()
+        dictionaryId
+    }
+```
+
+`id` теперь `Long?`. `getDictionaryById(id)` — `id` nullable.
+
+**Было:**
+```kotlin
+.mapLatest { id ->
+    val dictionaryId = dictionaryApi
+            .getDictionaryById(id)?.id?.toInt()
+            ?: dictionaryApi.getDictionaryList().firstOrNull()?.id?.toInt()
+    dictionaryId
+}
+```
+
+**Стало:**
+```kotlin
+.mapLatest { id ->
+    val dictionaryId = id?.let { dictionaryApi.getDictionaryById(it)?.id?.toInt() }
+            ?: dictionaryApi.getDictionaryList().firstOrNull()?.id?.toInt()
+    dictionaryId
+}
+```
+
+При `id == null` → пропускаем `getDictionaryById`, сразу fallback. Три метода — одинаковое изменение.
+
+### #4 DictionaryAppBarUseCaseImplTest.kt [~]
+
+Файл: `app/src/test/java/me/apomazkin/polytrainer/di/module/widget/DictionaryAppBarUseCaseImplTest.kt`
+
+Мок `prefsProvider.getLongFlow()` возвращает `MutableStateFlow<Long>` — после изменения нужен `MutableStateFlow<Long?>`.
+
+**Было:**
+```kotlin
+val prefsFlow = MutableStateFlow<Long>(...)
+coEvery { prefsProvider.getLongFlow(any()) } returns prefsFlow
+```
+
+**Стало:**
+```kotlin
+val prefsFlow = MutableStateFlow<Long?>(...)
+coEvery { prefsProvider.getLongFlow(any()) } returns prefsFlow
+```
+
+Добавить тест-кейс: "flowCurrentDict falls back to first dict when prefs ID is null" — `prefsFlow.value = null`.
+
+## Notes
+
+- `getIntFlow` фиксится аналогично, но сейчас нигде не вызывается — превентивный фикс
+- `getBooleanFlow` уже безопасный — не трогаем
+- Все потребители уже имеют fallback логику (первый словарь из списка) — null-обработка минимальна

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -39,4 +39,5 @@
 - [Стиль кода](code-style.md) — форматирование, именование, git-конвенции, gradle
 - [Логирование](logging.md) — LexemeLogger, sink-паттерн, уровни, теги, конфигурация
 - [Тема и ресурсы](theme-and-resources.md) — цвета, типографика, ResourceManager, иконки, превью
+- [Preferences](prefs-datastore.md) — DataStore, PrefsProvider, nullable Flow, ключи
 - [Утилиты](tools-utils.md) — хелперы для работы со списками (modifyFiltered, insertToEnd)

--- a/docs/guides/prefs-datastore.md
+++ b/docs/guides/prefs-datastore.md
@@ -1,0 +1,203 @@
+# Preferences (DataStore)
+
+## Модуль
+
+`modules/datasource/prefs` — пакет `me.apomazkin.prefs`.
+
+Единственный entry point для работы с локальными настройками. Обёртка над Jetpack DataStore.
+
+## Архитектура
+
+```
+PrefsProvider (class)
+    └── DataStore<Preferences> (delegate property)
+            └── файл: lexemePrefStore (на устройстве)
+```
+
+```kotlin
+class PrefsProvider(private val context: Context) {
+    private val Context.dataStore: DataStore<Preferences> 
+        by preferencesDataStore(name = "lexemePrefStore")
+}
+```
+
+- Один файл на всё приложение: `lexemePrefStore`
+- Провайдится как `@Singleton` через `PrefsProviderModule` в AppComponent
+- Не создавать вручную — только через DI
+
+## DI
+
+```kotlin
+// PrefsProviderModule.kt (app module)
+@Module
+class PrefsProviderModule {
+    @Singleton
+    @Provides
+    fun providePrefsProvider(context: Context): PrefsProvider = PrefsProvider(context)
+}
+```
+
+Доступен во всех UseCase'ах через constructor injection.
+
+## API
+
+### Flow-подписки (реактивные)
+
+Используются для реактивных подписок в UseCase'ах и FlowHandler'ах. Эмитят при каждом изменении значения.
+
+```kotlin
+fun getLongFlow(prefKey: PrefKey): Flow<Long?>     // nullable — ключ может не существовать
+fun getIntFlow(prefKey: PrefKey): Flow<Int?>       // nullable — ключ может не существовать
+fun getBooleanFlow(prefKey: PrefKey): Flow<Boolean> // не nullable — дефолт false
+```
+
+### Одноразовые чтения (suspend)
+
+Используются для разовых проверок в EffectHandler'ах.
+
+```kotlin
+suspend fun getLong(prefKey: PrefKey): Long?       // null = ключ не существует
+suspend fun getInt(prefKey: PrefKey): Int?         // null = ключ не существует
+suspend fun getBoolean(prefKey: PrefKey): Boolean? // null = ключ не существует
+```
+
+### Запись (suspend)
+
+```kotlin
+suspend fun setLong(prefKey: PrefKey, value: Long)
+suspend fun setInt(prefKey: PrefKey, value: Int)
+suspend fun setBoolean(prefKey: PrefKey, value: Boolean)
+```
+
+## Ключи
+
+```kotlin
+enum class PrefKey(val value: String) {
+    CURRENT_DICTIONARY_ID_LONG("LONG_currentDictionaryId"),
+    CHAT_EARLIEST_REVIEWED_STATUS_BOOLEAN("Boolean_chatEarliestReviewedStatus"),
+    CHAT_FREQUENT_MISTAKES_STATUS_BOOLEAN("Boolean_chatFrequentMistakesStatus"),
+    CHAT_DEBUG_STATUS_BOOLEAN("Boolean_chatDebugStatus")
+}
+```
+
+### Конвенция именования
+
+`TYPE_camelCaseName` — тип значения в префиксе:
+- `LONG_` для Long
+- `Boolean_` для Boolean
+- `INT_` для Int (пока не используется)
+
+### Кто использует какие ключи
+
+| Ключ | Чтение (Flow) | Чтение (suspend) | Запись |
+|------|--------------|-------------------|-------|
+| `CURRENT_DICTIONARY_ID_LONG` | DictionaryAppBarUseCase, DictionaryTabUseCase, StatisticUseCase | WordCardUseCase, QuizChatUseCase, DictionaryUseCase, DictionaryTabUseCase | DictionaryAppBarUseCase, QuizChatUseCase, DictionaryUseCase, DictionaryTabUseCase |
+| `CHAT_EARLIEST_REVIEWED_STATUS_BOOLEAN` | AppBarFlowHandler | QuizChatUseCase | DatasourceEffectHandler (chat) |
+| `CHAT_FREQUENT_MISTAKES_STATUS_BOOLEAN` | AppBarFlowHandler | QuizChatUseCase | DatasourceEffectHandler (chat) |
+| `CHAT_DEBUG_STATUS_BOOLEAN` | AppBarFlowHandler | QuizGameImpl | DatasourceEffectHandler (chat) |
+
+## Правила
+
+### 1. Nullable Flow — ОБЯЗАТЕЛЬНАЯ обработка null
+
+`getLongFlow()` и `getIntFlow()` возвращают nullable. Ключ может не существовать при:
+- Первом запуске приложения
+- Очистке данных приложения
+- Race condition (UI подписался раньше чем splash записал ключ)
+
+```kotlin
+// ПРАВИЛЬНО — fallback при null:
+prefsProvider.getLongFlow(PrefKey.CURRENT_DICTIONARY_ID_LONG)
+    .map { id: Long? ->
+        id?.let { dictionaryApi.getDictionaryById(it) }
+            ?: dictionaryApi.getDictionaryList().firstOrNull()
+    }
+
+// ПРАВИЛЬНО — filterNotNull если null невозможен по логике:
+prefsProvider.getLongFlow(PrefKey.CURRENT_DICTIONARY_ID_LONG)
+    .filterNotNull()
+    .flatMapLatest { id -> ... }
+
+// ЗАПРЕЩЕНО — force unwrap:
+prefsProvider.getLongFlow(PrefKey.CURRENT_DICTIONARY_ID_LONG)
+    .map { id -> dictionaryApi.getDictionaryById(id!!) }  // ← NPE
+
+// ЗАПРЕЩЕНО — throw на null:
+it[longPreferencesKey(prefKey.value)]
+    ?: throw IllegalStateException("not found")  // ← краш при первом запуске
+```
+
+### 2. Boolean Flow — дефолт false
+
+`getBooleanFlow()` возвращает `Flow<Boolean>` (не nullable) с дефолтом `false`. Toggle-флаги по умолчанию выключены.
+
+### 3. Запись перед чтением
+
+Для ключей, от которых зависит UI (например `CURRENT_DICTIONARY_ID_LONG`):
+- Запись происходит на **SplashScreen** при первом запуске
+- К моменту подписки ключ **обычно** уже есть
+- Nullable Flow — **страховка** на race condition
+
+### 4. Не кешировать
+
+```kotlin
+// ЗАПРЕЩЕНО — кеш в переменную:
+val currentDictId = prefsProvider.getLong(PrefKey.CURRENT_DICTIONARY_ID_LONG)
+// ... позже используется устаревшее значение
+
+// ПРАВИЛЬНО — подписка через Flow:
+prefsProvider.getLongFlow(PrefKey.CURRENT_DICTIONARY_ID_LONG)
+    .collect { id -> /* всегда актуальное */ }
+```
+
+DataStore сам нотифицирует об изменениях через Flow.
+
+### 5. Не использовать DataStore напрямую
+
+Весь доступ — через `PrefsProvider`. Не создавать второй DataStore, не обращаться к `context.dataStore` из других мест.
+
+### 6. Новый ключ — чеклист
+
+1. Добавить в `PrefKey` enum с конвенцией `TYPE_camelCaseName`
+2. Определить: нужен ли Flow или только suspend?
+3. Определить: кто пишет? кто читает?
+4. Если Flow — обработать null для Long/Int
+5. Обновить таблицу "Кто использует какие ключи" в этом гайде
+
+## Потоки данных
+
+### CURRENT_DICTIONARY_ID_LONG — жизненный цикл
+
+```
+1. SplashScreen → checkIfNeedAddDictionary()
+   └── нет словарей → создать → setLong(CURRENT_DICTIONARY_ID_LONG, id)
+   └── есть словари → setLong(CURRENT_DICTIONARY_ID_LONG, firstDict.id)
+
+2. DictionaryAppBarUseCase → changeDict(id)
+   └── setLong(CURRENT_DICTIONARY_ID_LONG, id)
+
+3. DictionaryTabUseCase → changeDictionary(id) / deleteDictionary(id)
+   └── setLong(CURRENT_DICTIONARY_ID_LONG, newId)
+
+4. Подписчики (getLongFlow):
+   ├── DictionaryAppBarUseCase.flowCurrentDict()
+   ├── DictionaryTabUseCase.flowCurrentDict()
+   └── StatisticUseCase.flowWordCount/flowLexemeCount/flowQuizStat()
+```
+
+### Boolean ключи — жизненный цикл
+
+```
+1. DatasourceEffectHandler (chat) → toggle on/off
+   └── setBoolean(PrefKey.CHAT_EARLIEST_REVIEWED_STATUS_BOOLEAN, true/false)
+
+2. Подписчики (getBooleanFlow):
+   └── AppBarFlowHandler → combine трёх boolean Flow → обновление AppBar состояния
+```
+
+## Ограничения DataStore
+
+- **Один файл** — все preferences в одном файле `lexemePrefStore`. При большом количестве ключей — все подписчики нотифицируются при любом изменении.
+- **Main thread safe** — DataStore работает на IO dispatcher внутри. Но `edit {}` — suspend, вызывать из корутины.
+- **Нет миграции** — при добавлении/удалении ключей миграция не нужна (key-value store). Старые ключи просто игнорируются.
+- **Нет типизации на уровне компиляции** — `PrefKey` enum не привязан к типу значения. Можно вызвать `getLong(BOOLEAN_KEY)` — компилятор не поймает. Конвенция именования (`TYPE_name`) — единственная защита.

--- a/modules/datasource/prefs/src/main/java/me/apomazkin/prefs/PrefsProvider.kt
+++ b/modules/datasource/prefs/src/main/java/me/apomazkin/prefs/PrefsProvider.kt
@@ -17,12 +17,9 @@ class PrefsProvider(
 ) {
     private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "lexemePrefStore")
 
-    fun getIntFlow(prefKey: PrefKey): Flow<Int> {
+    fun getIntFlow(prefKey: PrefKey): Flow<Int?> {
         return context.dataStore.data
-            .map {
-                it[intPreferencesKey(prefKey.value)]
-                    ?: throw IllegalStateException("PrefKey $prefKey not found")
-            }
+            .map { it[intPreferencesKey(prefKey.value)] }
     }
     
     suspend fun getInt(prefKey: PrefKey): Int? {
@@ -35,12 +32,9 @@ class PrefsProvider(
         }
     }
 
-    fun getLongFlow(prefKey: PrefKey): Flow<Long> {
+    fun getLongFlow(prefKey: PrefKey): Flow<Long?> {
         return context.dataStore.data
-            .map {
-                it[longPreferencesKey(prefKey.value)]
-                    ?: throw IllegalStateException("PrefKey $prefKey not found")
-            }
+            .map { it[longPreferencesKey(prefKey.value)] }
     }
 
     suspend fun getLong(prefKey: PrefKey): Long? {


### PR DESCRIPTION
## Summary
- Remove throw IllegalStateException from getLongFlow/getIntFlow
- Return Flow<Long?>/Flow<Int?> instead of crashing on missing key
- Update consumers: DictionaryAppBarUseCase, DictionaryTabUseCase, StatisticUseCase — null fallback to first dictionary
- New test: flowCurrentDict falls back when prefs ID is null
- New guide: docs/guides/prefs-datastore.md

Closes #474

## Test plan
- [x] All existing tests pass
- [x] New test: null prefs ID fallback
- [x] Lint clean, build OK